### PR TITLE
Implement view module feature.

### DIFF
--- a/src/main/java/tp/cap5buddy/logic/commands/ViewModuleCommand.java
+++ b/src/main/java/tp/cap5buddy/logic/commands/ViewModuleCommand.java
@@ -1,0 +1,41 @@
+package tp.cap5buddy.logic.commands;
+
+import java.util.ArrayList;
+
+import tp.cap5buddy.modules.Module;
+import tp.cap5buddy.modules.ModuleList;
+
+
+
+/**
+ * Represents the ViewModuleCommand class.
+ */
+public class ViewModuleCommand extends Command {
+    private static final String SUCCESS_MESSAGE = "Module details have been displayed successfully!";
+    private ArrayList<Module> modules;
+    private String moduleName;
+    //need a storage system
+    public ViewModuleCommand(String[] commandArguments) {
+        this.moduleName = commandArguments[3];
+    }
+
+    /**
+     * Executes the main function of this command, to view a specified module.
+     * @return String success message.
+     */
+    public ResultCommand execute(ModuleList modules) {
+        Module moduleToBeDisplayed = modules.getModule(moduleName);
+        return new ResultCommand(moduleToBeDisplayed.toString() + "\n"
+                + SUCCESS_MESSAGE, isExit());
+    }
+
+    /**
+     * Indicates if the application session has ended.
+     *
+     * @return False since the sessions has not been terminated.
+     */
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+}

--- a/src/main/java/tp/cap5buddy/logic/parser/ParserManager.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/ParserManager.java
@@ -51,6 +51,10 @@ public class ParserManager {
             parser = new EditModuleParser();
             command = parser.parse(this.nonCommand);
             return command;
+        case "viewmodule":
+            parser = new ViewModuleParser();
+            command = parser.parse(this.nonCommand);
+            return command;
         default:
             throw new ParseException("Invalid command");
         }

--- a/src/main/java/tp/cap5buddy/logic/parser/Prefix.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/Prefix.java
@@ -33,6 +33,9 @@ public class Prefix {
         case "e/":
             res = true;
             break;
+        case "v/":
+            res = true;
+            break;
         default:
             res = false;
         }

--- a/src/main/java/tp/cap5buddy/logic/parser/PrefixList.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/PrefixList.java
@@ -5,5 +5,6 @@ public class PrefixList {
     public static final Prefix MODULE_NAME_PREFIX = new Prefix("n/");
     public static final Prefix MODULE_LINK_PREFIX = new Prefix("l/");
     public static final Prefix MODULE_NEWNAME_PREFIX = new Prefix("e/");
+    public static final Prefix MODULE_VIEW_PREFIX = new Prefix("v/");
 
 }

--- a/src/main/java/tp/cap5buddy/logic/parser/Tokenizer.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/Tokenizer.java
@@ -5,7 +5,7 @@ package tp.cap5buddy.logic.parser;
  * Represents the token of each user input.
  */
 public class Tokenizer {
-    private static final int SIZE = 3; // updates as the number of prefixes increases.
+    private static final int SIZE = 4; // updates as the number of prefixes increases.
     private String[] words = new String[SIZE];
     private String input;
 
@@ -32,6 +32,8 @@ public class Tokenizer {
                 this.words[1] = word;
             } else if (prefix.equals(PrefixList.MODULE_NEWNAME_PREFIX.toString())) {
                 this.words[2] = word;
+            } else if (prefix.equals(PrefixList.MODULE_VIEW_PREFIX.toString())) {
+                this.words[3] = word;
             } else {
                 // throws error as invalid prefix is found
             }

--- a/src/main/java/tp/cap5buddy/logic/parser/ViewModuleParser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/ViewModuleParser.java
@@ -1,0 +1,22 @@
+package tp.cap5buddy.logic.parser;
+
+import tp.cap5buddy.logic.commands.Command;
+import tp.cap5buddy.logic.commands.ViewModuleCommand;
+
+/**
+ * Represents the parser that handles View Module command.
+ */
+public class ViewModuleParser extends Parser {
+
+    /**
+     * Parses a user input for a command to view a stored module.
+     *
+     * @param userInput
+     * @return
+     */
+    public Command parse(String userInput) {
+        Tokenizer token = new Tokenizer(userInput);
+        String[] mod = token.getWords();
+        return new ViewModuleCommand(mod);
+    }
+}

--- a/src/main/java/tp/cap5buddy/modules/Module.java
+++ b/src/main/java/tp/cap5buddy/modules/Module.java
@@ -50,4 +50,9 @@ public class Module {
     public Module addZoomLink(String zoomLink) {
         return new Module(this.getName(), zoomLink);
     }
+
+    @Override
+    public String toString() {
+        return String.format("The zoom link for %s is %s", getName(), getLink());
+    }
 }


### PR DESCRIPTION
fixes #31 

Add ViewModuleCommand class.
Add ViewModuleParser class.
Update ParserManager class : Add the case for "viewmodule" under parse() method.
Update Prefix class : Add the case for "v/" under isPrefix() method.
Update PrefixList class : Add prefix "v/" to represent new name of a module.
Update Tokenizer class :
Add additional condition to get name of a module to be viewed
Name of module to be viewed will be stored in words[3]
Update Module class :
Overridden toString method to return the name and zoom link.