### PR TITLE
Update tokenizer to handle parsing of user input

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -76,7 +76,7 @@ public class ArgumentTokenizer {
     }
 
     /**
-     * Extracts prefixes and their argument values, and returns an {@code ArgumentMultimap} object that maps the
+     * Extracts prefixes and their argument values, and     returns an {@code ArgumentMultimap} object that maps the
      * extracted prefixes to their respective arguments. Prefixes are extracted based on their zero-based positions in
      * {@code argsString}.
      *

--- a/src/main/java/tp/cap5buddy/logic/commands/AddZoomLinkCommand.java
+++ b/src/main/java/tp/cap5buddy/logic/commands/AddZoomLinkCommand.java
@@ -40,7 +40,6 @@ public class AddZoomLinkCommand extends Command {
         Module updatedModule = module.addZoomLink(this.zoomLink);
         modules.updateModule(index, updatedModule);
         String successMessage = createSuccessMessage(updatedModule.getName());
-        System.out.println("link is" + updatedModule.getLink());
         return new ResultCommand(successMessage, isExit());
     }
 

--- a/src/main/java/tp/cap5buddy/logic/parser/AddZoomLinkParser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/AddZoomLinkParser.java
@@ -15,14 +15,17 @@ public class AddZoomLinkParser extends Parser {
     public AddZoomLinkCommand parse(String userInput) throws ParseException {
         Tokenizer tokenizer = new Tokenizer();
         String[] parsedArguments = tokenizer.tokenize(userInput,
-                PrefixList.MODULE_NAME_PREFIX, PrefixList.MODULE_LINK_PREFIX, PrefixList.MODULE_INDEX_PREFIX,
+                PrefixList.MODULE_NAME_PREFIX, PrefixList.MODULE_INDEX_PREFIX, PrefixList.MODULE_LINK_PREFIX,
                 PrefixList.MODULE_NEWNAME_PREFIX, PrefixList.MODULE_VIEW_PREFIX, PrefixList.MODULE_DELETE_PREFIX);
         try {
-            int moduleID = Integer.parseInt(parsedArguments[2]);
+            int moduleID = Integer.parseInt(parsedArguments[0]);
             String zoomLink = parsedArguments[1];
             return new AddZoomLinkCommand(moduleID, zoomLink);
         } catch (NumberFormatException ex) {
             String error = "No module ID was provided";
+            throw new ParseException(error);
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            String error = "Missing arguments";
             throw new ParseException(error);
         }
     }

--- a/src/main/java/tp/cap5buddy/logic/parser/AddZoomLinkParser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/AddZoomLinkParser.java
@@ -1,6 +1,7 @@
 package tp.cap5buddy.logic.parser;
 
 import tp.cap5buddy.logic.commands.AddZoomLinkCommand;
+import tp.cap5buddy.logic.parser.exception.ParseException;
 
 public class AddZoomLinkParser extends Parser {
 
@@ -10,9 +11,10 @@ public class AddZoomLinkParser extends Parser {
      * @param userInput
      * @return
      */
-    public AddZoomLinkCommand parse(String userInput) {
-        Tokenizer token = new Tokenizer(userInput);
-        String[] parsedArguments = token.getWords();
+    public AddZoomLinkCommand parse(String userInput) throws ParseException {
+        Tokenizer tokenizer = new Tokenizer();
+        String[] parsedArguments = tokenizer.tokenize(userInput,
+                PrefixList.MODULE_NAME_PREFIX, PrefixList.MODULE_LINK_PREFIX, PrefixList.MO)
         return new AddZoomLinkCommand(parsedArguments);
     }
 }

--- a/src/main/java/tp/cap5buddy/logic/parser/Parser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/Parser.java
@@ -1,13 +1,14 @@
 package tp.cap5buddy.logic.parser;
 
 import tp.cap5buddy.logic.commands.Command;
+import tp.cap5buddy.logic.parser.exception.ParseException;
 
 /**
  * Represents the super class of all Parser commands.
  */
 public abstract class Parser {
 
-    public abstract Command parse(String userInput);
+    public abstract Command parse(String userInput) throws ParseException;
 
     // public abstract ResultCommand execute();
 }

--- a/src/main/java/tp/cap5buddy/logic/parser/ParserManager.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/ParserManager.java
@@ -45,7 +45,7 @@ public class ParserManager {
             return command;
         case "addzoom":
             parser = new AddZoomLinkParser();
-            command = parser.parse(this.nonCommand);
+            command = parser.parse(input);
             return command;
         case "editmodule":
             parser = new EditModuleParser();

--- a/src/main/java/tp/cap5buddy/logic/parser/PrefixList.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/PrefixList.java
@@ -3,8 +3,8 @@ package tp.cap5buddy.logic.parser;
 public class PrefixList {
 
     public static final Prefix MODULE_NAME_PREFIX = new Prefix("n/");
-    public static final Prefix MODULE_LINK_PREFIX = new Prefix("l/");
     public static final Prefix MODULE_INDEX_PREFIX = new Prefix("i/");
+    public static final Prefix MODULE_LINK_PREFIX = new Prefix("l/");
     public static final Prefix MODULE_NEWNAME_PREFIX = new Prefix("e/");
     public static final Prefix MODULE_VIEW_PREFIX = new Prefix("v/");
     public static final Prefix MODULE_DELETE_PREFIX = new Prefix("d/");

--- a/src/main/java/tp/cap5buddy/logic/parser/Tokenizer.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/Tokenizer.java
@@ -1,9 +1,9 @@
 package tp.cap5buddy.logic.parser;
 
-import tp.cap5buddy.logic.parser.exception.ParseException;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import tp.cap5buddy.logic.parser.exception.ParseException;
 
 /**
  * Represents the token of each user input.
@@ -27,11 +27,27 @@ public class Tokenizer {
 
     }
 
-    public String[] tokenize(String userInput, Prefix... prefixes ) throws ParseException {
+    /**
+     * Tokenizes a user input based on prefixes.
+     *
+     * @param userInput User input
+     * @param prefixes Array of prefixes
+     * @return String array containing command arguments
+     * @throws ParseException If the user input could not be parsed.
+     */
+    public String[] tokenize(String userInput, Prefix... prefixes) throws ParseException {
         List<PrefixPosition> prefixPositions = findAllPrefixPositions(userInput, prefixes);
         return extractArguments(userInput, prefixPositions);
     }
 
+    /**
+     *
+     *
+     * @param userInput User input
+     * @param prefixes Array of prefixes
+     * @return List of prefix positions
+     * @throws ParseException If the input could not be parsed.
+     */
     public List<PrefixPosition> findAllPrefixPositions(String userInput, Prefix... prefixes) throws ParseException {
         List<PrefixPosition> prefixPositions = new ArrayList<>();
         for (Prefix prefix : prefixes) {
@@ -43,6 +59,14 @@ public class Tokenizer {
         return prefixPositions;
     }
 
+    /**
+     * Finds the position of the prefix in the user input.
+     *
+     * @param userInput User input.
+     * @param prefix Prefix.
+     * @return Prefix position.
+     * @throws ParseException If the same prefix is used more than once by the user.
+     */
     public PrefixPosition findPrefixPosition(String userInput, Prefix prefix) throws ParseException {
         String prefixSearch = " " + prefix.getPrefix();
         int prefixIndex = userInput.indexOf(prefixSearch);
@@ -55,12 +79,27 @@ public class Tokenizer {
         return (prefixIndex == -1 ? null : new PrefixPosition(prefixIndex + 1, prefix));
     }
 
+    /**
+     * Determines if the same prefix is used more than once.
+     *
+     * @param userInput User input.
+     * @param prefix Prefix.
+     * @param currentPrefixIndex Index of the current prefix in the user input.
+     * @return boolean.
+     */
     public boolean hasMultipleSamePrefixes(String userInput, Prefix prefix, int currentPrefixIndex) {
         int nextPrefixIndex = userInput.indexOf(" " + prefix.getPrefix(), currentPrefixIndex + 1);
         boolean hasMultipleSamePrefix = nextPrefixIndex != -1;
         return hasMultipleSamePrefix;
     }
 
+    /**
+     * Extracts the command arguments using the list of prefix positions.
+     *
+     * @param userInput User input.
+     * @param prefixPositions Prefix positions.
+     * @return String array containing the command arguments.
+     */
     public String[] extractArguments(String userInput, List<PrefixPosition> prefixPositions) {
         String[] results = new String[SIZE];
         PrefixPosition endPositionMarker = new PrefixPosition(userInput.length(), new Prefix(""));
@@ -72,6 +111,14 @@ public class Tokenizer {
         return results;
     }
 
+    /**
+     * Extracts the argument of a prefix.
+     *
+     * @param userInput User input.
+     * @param currentPrefixPosition Current index of the prefix.
+     * @param nextPrefixPosition Next prefix index.
+     * @return String containing the command argument for the current prefix.
+     */
     public String extractArgument(String userInput,
                                   PrefixPosition currentPrefixPosition,
                                   PrefixPosition nextPrefixPosition) {

--- a/src/main/java/tp/cap5buddy/logic/parser/Tokenizer.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/Tokenizer.java
@@ -1,6 +1,5 @@
 package tp.cap5buddy.logic.parser;
 
-
 import tp.cap5buddy.logic.parser.exception.ParseException;
 
 import java.util.ArrayList;
@@ -10,7 +9,7 @@ import java.util.List;
  * Represents the token of each user input.
  */
 public class Tokenizer {
-    private static final int SIZE = 5; // updates as the number of prefixes increases.
+    private static final int SIZE = 6; // updates as the number of prefixes increases.
     private String[] words = new String[SIZE];
     private String input;
 
@@ -64,7 +63,9 @@ public class Tokenizer {
 
     public String[] extractArguments(String userInput, List<PrefixPosition> prefixPositions) {
         String[] results = new String[SIZE];
-        for (int i = 0; i < SIZE - 1; i++) {
+        PrefixPosition endPositionMarker = new PrefixPosition(userInput.length(), new Prefix(""));
+        prefixPositions.add(endPositionMarker);
+        for (int i = 0; i < prefixPositions.size() - 1; i++) {
             String argument = extractArgument(userInput, prefixPositions.get(i), prefixPositions.get(i + 1));
             results[i] = argument;
         }


### PR DESCRIPTION
Fixes #126 

This PR modifies the tokenizer class to retrieve the entire command argument by using the indexes of prefix within the user input, followed by retrieving the substring between the indexes of 2 consecutive prefixes.