### PR TITLE
Implement edit contact command for contact list

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -43,6 +43,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
+
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }

--- a/src/main/java/tp/cap5buddy/logic/commands/EditContactCommand.java
+++ b/src/main/java/tp/cap5buddy/logic/commands/EditContactCommand.java
@@ -1,0 +1,126 @@
+package tp.cap5buddy.logic.commands;
+
+import java.util.Optional;
+
+import tp.cap5buddy.contacts.Contact;
+import tp.cap5buddy.contacts.ContactList;
+import tp.cap5buddy.contacts.Email;
+import tp.cap5buddy.contacts.Name;
+import tp.cap5buddy.contacts.exceptions.ContactNotFoundException;
+import tp.cap5buddy.contacts.exceptions.DuplicateContactException;
+import tp.cap5buddy.logic.commands.exception.CommandException;
+import tp.cap5buddy.modules.ModuleList;
+import tp.cap5buddy.util.CollectionUtil;
+
+public class EditContactCommand extends Command {
+
+    private final int contactID;
+    private final EditContactDescriptor editContactDescriptor;
+
+    /**
+     * Creates and initialises a EditContactCommand object.
+     *
+     * @param contactID ID of the contact.
+     * @param editContactDescriptor EditContactDescriptor object containing the updated contact details.
+     */
+    public EditContactCommand(int contactID, EditContactDescriptor editContactDescriptor) {
+        this.contactID = contactID;
+        this.editContactDescriptor = editContactDescriptor;
+    }
+
+    @Override
+    public CommandResult execute(ModuleList modules, ContactList contacts) throws CommandException {
+        try {
+            Contact contactToEdit = contacts.getContact(this.contactID - 1);
+            Contact editedContact = createEditedContact(contactToEdit, this.editContactDescriptor);
+            contacts.editContact(contactToEdit, editedContact);
+            String successMessage = createSuccessMessage(contactToEdit, editedContact);
+            return new CommandResult(successMessage, isExit());
+        } catch (ContactNotFoundException | DuplicateContactException ex) {
+            String error = "The contact could not be edited as the contact was not found/already exists";
+            throw new CommandException(error);
+        }
+    }
+
+    /**
+     * Creates and returns a {@code Contact} with the details of {@code contactToEdit}
+     * edited with {@code editContactDescriptor}.
+     */
+    private static Contact createEditedContact(Contact contactToEdit, EditContactDescriptor editContactDescriptor) {
+        assert contactToEdit != null;
+
+        Name updatedName = editContactDescriptor.getName().orElse(contactToEdit.getName());
+        Email updatedEmail = editContactDescriptor.getEmail().orElse(contactToEdit.getEmail());
+
+        return new Contact(updatedName, updatedEmail);
+    }
+
+    /**
+     * Creates success message after successfully executing this command.
+     *
+     * @param contactToEdit the original contact.
+     * @param editedContact the contact after editing.
+     * @return String that represent a success message followed by the content of the original
+     *         contact and the content after the contact has been edited.
+     */
+    public String createSuccessMessage(Contact contactToEdit, Contact editedContact) {
+        String message = ""
+                + "Contact " + this.contactID + " has been successfully edited!\n\n"
+                + "Original Contact: \n"
+                + "Name: " + contactToEdit.getName().toString() + "\n"
+                + "Email: " + contactToEdit.getEmail().toString() + "\n\n"
+                + "New Contact: \n"
+                + "Name: " + editedContact.getName().toString() + "\n"
+                + "Email: " + editedContact.getEmail().toString() + "\n";
+        return message;
+    }
+
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+
+    /**
+     * Stores the details to edit the person with. Each non-empty field value will replace the
+     * corresponding field value of the person.
+     */
+    public static class EditContactDescriptor {
+        private Name name;
+        private Email email;
+
+        public EditContactDescriptor() {
+        }
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditContactDescriptor(EditContactDescriptor toCopy) {
+            setName(toCopy.name);
+            setEmail(toCopy.email);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, email);
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setEmail(Email email) {
+            this.email = email;
+        }
+
+        public Optional<Email> getEmail() {
+            return Optional.ofNullable(email);
+        }
+    }
+}

--- a/src/main/java/tp/cap5buddy/logic/parser/EditContactParser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/EditContactParser.java
@@ -1,0 +1,35 @@
+package tp.cap5buddy.logic.parser;
+
+import tp.cap5buddy.logic.commands.Command;
+import tp.cap5buddy.logic.commands.EditContactCommand;
+import tp.cap5buddy.logic.commands.EditContactCommand.EditContactDescriptor;
+import tp.cap5buddy.logic.parser.exception.ParseException;
+
+public class EditContactParser extends Parser {
+
+    @Override
+    public Command parse(String userInput) throws ParseException {
+        Tokenizer tokenizer = new Tokenizer(userInput, PrefixList.CONTACT_INDEX_PREFIX,
+                PrefixList.CONTACT_NAME_PREFIX, PrefixList.CONTACT_EMAIL_PREFIX);
+        String[] parsedArguments = tokenizer.tokenize();
+        try {
+            int contactID = Integer.parseInt(parsedArguments[0]);
+            String name = parsedArguments[1];
+            String email = parsedArguments[2];
+            EditContactDescriptor editPersonDescriptor = new EditContactDescriptor();
+            editPersonDescriptor.setName(ParserUtil.parseName(name));
+            editPersonDescriptor.setEmail(ParserUtil.parseEmail(email));
+            if (!editPersonDescriptor.isAnyFieldEdited()) {
+                String error = "At least one contact field must be edited";
+                throw new ParseException(error);
+            }
+            return new EditContactCommand(contactID, editPersonDescriptor);
+        } catch (NumberFormatException ex) {
+            String error = "No contact ID provided";
+            throw new ParseException(error);
+        } catch (ParseException ex) {
+            String error = "error";
+            throw new ParseException(error);
+        }
+    }
+}

--- a/src/main/java/tp/cap5buddy/logic/parser/ParserManager.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/ParserManager.java
@@ -62,6 +62,10 @@ public class ParserManager {
             parser = new AddContactParser();
             command = parser.parse(input);
             return command;
+        case "editcontact":
+            parser = new EditContactParser();
+            command = parser.parse(input);
+            return command;
         default:
             throw new ParseException("Invalid Command");
         }

--- a/src/main/java/tp/cap5buddy/logic/parser/ParserUtil.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/ParserUtil.java
@@ -1,0 +1,47 @@
+package tp.cap5buddy.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+
+import tp.cap5buddy.contacts.Email;
+import tp.cap5buddy.contacts.Name;
+import tp.cap5buddy.logic.parser.exception.ParseException;
+
+/**
+ * Contains utility methods used for parsing strings in the various *Parser classes.
+ */
+public class ParserUtil {
+
+    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+
+    /**
+     * Parses a {@code String name} into a {@code Name}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid.
+     */
+    public static Name parseName(String name) throws ParseException {
+        requireNonNull(name);
+        String trimmedName = name.trim();
+        if (!Name.isValidName(trimmedName)) {
+            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+        }
+        return new Name(trimmedName);
+    }
+
+    /**
+     * Parses a {@code String email} into an {@code Email}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code email} is invalid.
+     */
+    public static Email parseEmail(String email) throws ParseException {
+        requireNonNull(email);
+        String trimmedEmail = email.trim();
+
+        // if (!Email.isValidEmail(trimmedEmail)) {
+        //     throw new ParseException(Email.MESSAGE_CONSTRAINTS);
+        // }
+
+        return new Email(trimmedEmail);
+    }
+}


### PR DESCRIPTION
Fixes #153 

This PR adds the implementation of the command for editing contacts in the user's contact list. The implementation includes the parsing of the user input and the execution of the command to edit a contact.

The following classes were added:
1. EditContactParser
2. EditContactCommand
3. ParserUtil (to handle parsing of newly added Name and Email)