### PR TITLE
Implement storage functionality for contact list

### DIFF
--- a/src/main/java/tp/cap5buddy/Cap5buddy.java
+++ b/src/main/java/tp/cap5buddy/Cap5buddy.java
@@ -11,8 +11,8 @@ import tp.cap5buddy.logic.LogicManager;
 import tp.cap5buddy.logic.commands.CommandResult;
 import tp.cap5buddy.logic.commands.exception.CommandException;
 import tp.cap5buddy.logic.parser.exception.ParseException;
-import tp.cap5buddy.modules.Module;
 import tp.cap5buddy.modules.ModuleList;
+import tp.cap5buddy.storage.JsonContactListStorage;
 import tp.cap5buddy.storage.JsonModuleListStorage;
 import tp.cap5buddy.storage.StorageManager;
 import tp.cap5buddy.ui.Ui;
@@ -36,22 +36,32 @@ public class Cap5buddy {
 
     private static void run(Ui ui) throws ParseException, CommandException {
         boolean isExit = false;
-        Path saveDir = Paths.get(".\\data\\moduleList.json");
-        JsonModuleListStorage storageList = new JsonModuleListStorage(saveDir);
-        StorageManager storage = new StorageManager(storageList);
+        Path contactsSaveDir = Paths.get(".\\data\\contactList.json");
+        Path modulesSaveDir = Paths.get(".\\data\\moduleList.json");
+        JsonModuleListStorage moduleStorageList = new JsonModuleListStorage(modulesSaveDir);
+        JsonContactListStorage contactStorageList = new JsonContactListStorage(contactsSaveDir);
+        StorageManager storage = new StorageManager(moduleStorageList, contactStorageList);
         ModuleList moduleList;
+        ContactList contactList;
         try {
-            Optional<ModuleList> optionalModuleList = storageList.readModuleList();
+            Optional<ModuleList> optionalModuleList = moduleStorageList.readModuleList();
             if (optionalModuleList.isEmpty()) {
-                moduleList = new ModuleList(new ArrayList<Module>());
+                moduleList = new ModuleList(new ArrayList<>());
             } else {
-                moduleList = storageList.readModuleList().get();
+                moduleList = moduleStorageList.readModuleList().get();
+            }
+            Optional<ContactList> optionalContactList = contactStorageList.readContactList();
+            if (optionalContactList.isEmpty()) {
+                contactList = new ContactList(new ArrayList<>());
+            } else {
+                contactList = contactStorageList.readContactList().get();
             }
         } catch (DataConversionException e) {
             System.out.println(e.getMessage());
-            moduleList = new ModuleList(new ArrayList<Module>());
+            moduleList = new ModuleList(new ArrayList<>());
+            contactList = new ContactList(new ArrayList<>());
         }
-        LogicManager lm = new LogicManager(storage, moduleList, new ContactList(new ArrayList<>()));
+        LogicManager lm = new LogicManager(storage, moduleList, contactList);
         while (!isExit) {
             String current = ui.getInput();
             CommandResult res = lm.execute(current);

--- a/src/main/java/tp/cap5buddy/contacts/ContactList.java
+++ b/src/main/java/tp/cap5buddy/contacts/ContactList.java
@@ -2,6 +2,7 @@ package tp.cap5buddy.contacts;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import tp.cap5buddy.contacts.exceptions.ContactNotFoundException;
@@ -13,6 +14,10 @@ public class ContactList {
 
     public ContactList(List<Contact> contacts) {
         this.contacts = contacts;
+    }
+
+    public ContactList() {
+        this.contacts = new ArrayList<>();
     }
 
     /**

--- a/src/main/java/tp/cap5buddy/logic/LogicManager.java
+++ b/src/main/java/tp/cap5buddy/logic/LogicManager.java
@@ -47,6 +47,7 @@ public class LogicManager implements Logic {
         CommandResult result = command.execute(moduleList, contactList);
         try {
             storage.saveModuleList(moduleList);
+            storage.saveContactList(contactList);
         } catch (IOException ioe) {
             System.out.println(ioe.getMessage());
         }

--- a/src/main/java/tp/cap5buddy/storage/ContactListStorage.java
+++ b/src/main/java/tp/cap5buddy/storage/ContactListStorage.java
@@ -1,0 +1,45 @@
+package tp.cap5buddy.storage;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import seedu.address.commons.exceptions.DataConversionException;
+import tp.cap5buddy.contacts.ContactList;
+
+/**
+ * Represents a storage for {@link tp.cap5buddy.contacts.ContactList}.
+ */
+public interface ContactListStorage {
+
+    /**
+     * Returns the file path of the data file.
+     */
+    Path getContactListFilePath();
+
+    /**
+     * Returns ContactList data as a {@link ContactList}.
+     *   Returns {@code Optional.empty()} if storage file is not found.
+     * @throws DataConversionException if the data in storage is not in the expected format.
+     * @throws IOException if there was any problem when reading from the storage.
+     */
+    Optional<ContactList> readContactList() throws DataConversionException, IOException;
+
+    /**
+     * @see #getContactListFilePath()
+     */
+    Optional<ContactList> readContactList(Path filePath) throws DataConversionException, IOException;
+
+    /**
+     * Saves the given {@link ContactList} to the storage.
+     * @param contactList cannot be null.
+     * @throws IOException if there was any problem writing to the file.
+     */
+    void saveContactList(ContactList contactList) throws IOException;
+
+    /**
+     * @see #saveContactList(ContactList)
+     */
+    void saveContactList(ContactList contactList, Path filePath) throws IOException;
+
+}

--- a/src/main/java/tp/cap5buddy/storage/JsonAdaptedContact.java
+++ b/src/main/java/tp/cap5buddy/storage/JsonAdaptedContact.java
@@ -1,0 +1,49 @@
+package tp.cap5buddy.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import tp.cap5buddy.contacts.Contact;
+import tp.cap5buddy.contacts.Email;
+import tp.cap5buddy.contacts.Name;
+
+/**
+ * Jackson-friendly version of {@link Contact}.
+ */
+class JsonAdaptedContact {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Contact's %s field is missing!";
+
+    private final String name;
+    private final String email;
+
+    /**
+     * Constructs a {@code JsonAdaptedModule} with the given person details.
+     */
+    @JsonCreator
+    public JsonAdaptedContact(@JsonProperty("name") String name, @JsonProperty("email") String email) {
+        this.name = name;
+        this.email = email;
+    }
+
+    /**
+     * Converts a given {@code Contact} into this class for Jackson use.
+     */
+    public JsonAdaptedContact(Contact source) {
+        name = source.getName().toString();
+        email = source.getEmail().toString();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted module object into the model's {@code Module} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted module.
+     */
+    public Contact toModelType() throws IllegalValueException {
+        Name name = new Name(this.name);
+        Email email = new Email(this.email);
+        return new Contact(name, email);
+    }
+
+}

--- a/src/main/java/tp/cap5buddy/storage/JsonContactListStorage.java
+++ b/src/main/java/tp/cap5buddy/storage/JsonContactListStorage.java
@@ -1,0 +1,74 @@
+package tp.cap5buddy.storage;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.FileUtil;
+import seedu.address.commons.util.JsonUtil;
+import tp.cap5buddy.contacts.ContactList;
+
+
+
+/**
+ * A class to access CAP5Buddy data stored as a json file on the hard disk.
+ */
+public class JsonContactListStorage implements ContactListStorage {
+    private static final Logger logger = LogsCenter.getLogger(JsonModuleListStorage.class);
+    private Path filePath;
+
+    public JsonContactListStorage(Path filePath) {
+        this.filePath = filePath;
+    }
+
+    public Path getContactListFilePath() {
+        return filePath;
+    }
+
+    public Optional<ContactList> readContactList() throws DataConversionException {
+        return readContactList(filePath);
+    }
+
+    @Override
+    public Optional<ContactList> readContactList(Path filePath) throws DataConversionException {
+        requireNonNull(filePath);
+
+        Optional<JsonSerializableContactList> jsonContactList = JsonUtil.readJsonFile(
+                filePath, JsonSerializableContactList.class);
+        if (!jsonContactList.isPresent()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(jsonContactList.get().toModelType());
+        } catch (IllegalValueException ive) {
+            logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
+            throw new DataConversionException(ive);
+        }
+    }
+
+    @Override
+    public void saveContactList(ContactList contactList) throws IOException {
+        saveContactList(contactList, filePath);
+    }
+
+    /**
+     * Similar to {@link #saveContactList(ContactList)}.
+     * @param contactList
+     * @param filePath
+     * @throws IOException
+     */
+    public void saveContactList(ContactList contactList, Path filePath) throws IOException {
+        requireNonNull(contactList);
+        requireNonNull(filePath);
+
+        FileUtil.createIfMissing(filePath);
+        JsonUtil.saveJsonFile(new JsonSerializableContactList(contactList), filePath);
+    }
+
+}

--- a/src/main/java/tp/cap5buddy/storage/JsonSerializableContactList.java
+++ b/src/main/java/tp/cap5buddy/storage/JsonSerializableContactList.java
@@ -1,0 +1,57 @@
+package tp.cap5buddy.storage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import tp.cap5buddy.contacts.Contact;
+import tp.cap5buddy.contacts.ContactList;
+
+
+/**
+ * An Immutable ContactList that is serializable to JSON format.
+ */
+@JsonRootName(value = "addressbook")
+class JsonSerializableContactList {
+
+    public static final String MESSAGE_DUPLICATE_PERSON = "Contacts list contains duplicate module(s).";
+
+    private final List<JsonAdaptedContact> contacts = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonSerializableContactList} with the given contacts.
+     */
+    @JsonCreator
+    public JsonSerializableContactList(@JsonProperty("contacts") List<JsonAdaptedContact> contacts) {
+        this.contacts.addAll(contacts);
+    }
+
+    /**
+     * Converts a given {@code ContactList} into this class for Jackson use.
+     *
+     * @param source future changes to this will not affect the created {@code JsonSerializableContactList}.
+     */
+    public JsonSerializableContactList(ContactList source) {
+        contacts.addAll(source.getContactList().stream().map(JsonAdaptedContact::new).collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this contact list into the model's {@code ContactList} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated.
+     */
+    public ContactList toModelType() throws IllegalValueException {
+        ContactList contactList = new ContactList();
+        for (JsonAdaptedContact jsonAdaptedContact: contacts) {
+            Contact contact = jsonAdaptedContact.toModelType();
+            contactList.addContact(contact);
+        }
+        return contactList;
+    }
+
+}

--- a/src/main/java/tp/cap5buddy/storage/ModuleListStorage.java
+++ b/src/main/java/tp/cap5buddy/storage/ModuleListStorage.java
@@ -7,8 +7,6 @@ import java.util.Optional;
 import seedu.address.commons.exceptions.DataConversionException;
 import tp.cap5buddy.modules.ModuleList;
 
-
-
 /**
  * Represents a storage for {@link seedu.address.model.AddressBook}.
  */

--- a/src/main/java/tp/cap5buddy/storage/Storage.java
+++ b/src/main/java/tp/cap5buddy/storage/Storage.java
@@ -5,20 +5,30 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.address.commons.exceptions.DataConversionException;
+import tp.cap5buddy.contacts.ContactList;
 import tp.cap5buddy.modules.ModuleList;
 
 
 /**
  * API of the Storage component
  */
-public interface Storage extends ModuleListStorage {
+public interface Storage extends ModuleListStorage, ContactListStorage {
     @Override
     Path getModuleListFilePath();
+
+    @Override
+    Path getContactListFilePath();
 
     @Override
     Optional<ModuleList> readModuleList() throws DataConversionException, IOException;
 
     @Override
+    Optional<ContactList> readContactList() throws DataConversionException, IOException;
+
+    @Override
     void saveModuleList(ModuleList moduleList) throws IOException;
+
+    @Override
+    void saveContactList(ContactList contactList, Path filePath) throws IOException;
 
 }

--- a/src/main/java/tp/cap5buddy/storage/StorageManager.java
+++ b/src/main/java/tp/cap5buddy/storage/StorageManager.java
@@ -7,9 +7,8 @@ import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataConversionException;
+import tp.cap5buddy.contacts.ContactList;
 import tp.cap5buddy.modules.ModuleList;
-
-
 
 /**
  * Manages storage of CAP5Buddy data in local storage.
@@ -18,18 +17,22 @@ public class StorageManager implements Storage {
 
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
     private ModuleListStorage moduleListStorage;
+    private ContactListStorage contactListStorage;
 
     /**
      * Creates a {@code StorageManager} with the given {@code ModuleListStorage} and {@code UserPrefStorage}.
      */
-    public StorageManager(ModuleListStorage moduleListStorage) {
+    public StorageManager(ModuleListStorage moduleListStorage,
+                          ContactListStorage contactListStorage) {
         super();
         this.moduleListStorage = moduleListStorage;
+        this.contactListStorage = contactListStorage;
     }
     @Override
     public Path getModuleListFilePath() {
         return moduleListStorage.getModuleListFilePath();
     }
+
     @Override
     public Optional<ModuleList> readModuleList() throws DataConversionException, IOException {
         return readModuleList(moduleListStorage.getModuleListFilePath());
@@ -49,6 +52,32 @@ public class StorageManager implements Storage {
     @Override
     public void saveModuleList(ModuleList moduleList, Path filePath) throws IOException {
         moduleListStorage.saveModuleList(moduleList, filePath);
+    }
+
+    @Override
+    public Path getContactListFilePath() {
+        return contactListStorage.getContactListFilePath();
+    }
+
+    @Override
+    public Optional<ContactList> readContactList() throws DataConversionException, IOException {
+        return readContactList(contactListStorage.getContactListFilePath());
+    }
+
+    @Override
+    public Optional<ContactList> readContactList(Path filePath) throws DataConversionException, IOException {
+        logger.fine("Attempting to read data from file: " + filePath);
+        return contactListStorage.readContactList(filePath);
+    }
+
+    @Override
+    public void saveContactList(ContactList contactList) throws IOException {
+        saveContactList(contactList, contactListStorage.getContactListFilePath());
+    }
+
+    @Override
+    public void saveContactList(ContactList contactList, Path filePath) throws IOException {
+        contactListStorage.saveContactList(contactList, filePath);
     }
 
 }


### PR DESCRIPTION
Fixes #162 

The current implementation of the contact list does not allow the storage of contacts for future use and reference.

This implementation is unsuitable as users will be unable to perform contact related commands on previously created contacts.

Let's
* Implement a storage of contacts using Json.
* Abstract out storage related methods to individual classes.
* Allow the main Cap5Buddy class to handle storage creation temporarily.

The following classes have been added:
1. ContactListStorage
2. JsonAdaptedContact
3. JsonContactListStorage
4. JsonSerializableContactList

Additionally, the StorageManager class is responsible for handling both the ModuleList and ContactList objects.