### PR TITLE
Update tokenizer to store prefix arguments in a hashmap

### DIFF
--- a/src/main/java/tp/cap5buddy/logic/parser/AddContactParser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/AddContactParser.java
@@ -14,14 +14,13 @@ public class AddContactParser extends Parser {
      */
     public AddContactCommand parse(String userInput) throws ParseException {
         Tokenizer tokenizer = new Tokenizer(userInput, PrefixList.CONTACT_NAME_PREFIX, PrefixList.CONTACT_EMAIL_PREFIX);
-        String[] parsedArguments = tokenizer.tokenize();
-        try {
-            String contactName = parsedArguments[0];
-            String contactEmail = parsedArguments[1];
-            return new AddContactCommand(contactName, contactEmail);
-        } catch (ArrayIndexOutOfBoundsException ex) {
-            String error = "Missing arguments";
+        ArgumentMap argumentMap = tokenizer.tokenize();
+        if (!argumentMap.arePrefixesPresent(PrefixList.CONTACT_NAME_PREFIX)) {
+            String error = "Missing prefix arguments";
             throw new ParseException(error);
         }
+        String contactName = argumentMap.getValue(PrefixList.CONTACT_NAME_PREFIX).get();
+        String contactEmail = argumentMap.getValue(PrefixList.CONTACT_EMAIL_PREFIX).orElse("");
+        return new AddContactCommand(contactName, contactEmail);
     }
 }

--- a/src/main/java/tp/cap5buddy/logic/parser/AddModuleParser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/AddModuleParser.java
@@ -19,9 +19,13 @@ public class AddModuleParser extends Parser {
      */
     public Command parse(String userInput) throws ParseException {
         Tokenizer token = new Tokenizer(userInput, PrefixList.MODULE_NAME_PREFIX, PrefixList.MODULE_LINK_PREFIX);
-        String[] parsedArguments = token.tokenize();
-        String modName = parsedArguments[0];
-        String modLink = parsedArguments[1];
+        ArgumentMap argumentMap = token.tokenize();
+        if (!argumentMap.arePrefixesPresent(PrefixList.MODULE_NAME_PREFIX)) {
+            String error = "Missing prefix arguments";
+            throw new ParseException(error);
+        }
+        String modName = argumentMap.getValue(PrefixList.MODULE_NAME_PREFIX).get();
+        String modLink = argumentMap.getValue(PrefixList.MODULE_LINK_PREFIX).orElse("");
         this.command = new AddModuleCommand(modName, modLink);
         return this.command;
     }

--- a/src/main/java/tp/cap5buddy/logic/parser/AddZoomLinkParser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/AddZoomLinkParser.java
@@ -15,16 +15,19 @@ public class AddZoomLinkParser extends Parser {
     public AddZoomLinkCommand parse(String userInput) throws ParseException {
         Tokenizer tokenizer = new Tokenizer(userInput,
                 PrefixList.MODULE_INDEX_PREFIX, PrefixList.MODULE_LINK_PREFIX);
-        String[] parsedArguments = tokenizer.tokenize();
+        ArgumentMap argumentMap = tokenizer.tokenize();
+
+        if (!argumentMap.arePrefixesPresent(PrefixList.MODULE_INDEX_PREFIX,
+                PrefixList.MODULE_LINK_PREFIX)) {
+            String error = "Missing prefix arguments";
+            throw new ParseException(error);
+        }
         try {
-            int moduleID = Integer.parseInt(parsedArguments[0]);
-            String zoomLink = parsedArguments[1];
+            int moduleID = Integer.parseInt(argumentMap.getValue(PrefixList.MODULE_INDEX_PREFIX).get());
+            String zoomLink = argumentMap.getValue(PrefixList.MODULE_LINK_PREFIX).get();
             return new AddZoomLinkCommand(moduleID, zoomLink);
         } catch (NumberFormatException ex) {
             String error = "No module ID was provided";
-            throw new ParseException(error);
-        } catch (ArrayIndexOutOfBoundsException ex) {
-            String error = "Missing arguments";
             throw new ParseException(error);
         }
     }

--- a/src/main/java/tp/cap5buddy/logic/parser/AddZoomLinkParser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/AddZoomLinkParser.java
@@ -15,7 +15,7 @@ public class AddZoomLinkParser extends Parser {
     public AddZoomLinkCommand parse(String userInput) throws ParseException {
         Tokenizer tokenizer = new Tokenizer();
         String[] parsedArguments = tokenizer.tokenize(userInput,
-                PrefixList.MODULE_NAME_PREFIX, PrefixList.MODULE_INDEX_PREFIX, PrefixList.MODULE_LINK_PREFIX,
+                PrefixList.MODULE_NAME_PREFIX, PrefixList.MODULE_LINK_PREFIX,
                 PrefixList.MODULE_NEWNAME_PREFIX, PrefixList.MODULE_VIEW_PREFIX, PrefixList.MODULE_DELETE_PREFIX);
         try {
             int moduleID = Integer.parseInt(parsedArguments[0]);

--- a/src/main/java/tp/cap5buddy/logic/parser/ArgumentMap.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/ArgumentMap.java
@@ -1,0 +1,52 @@
+package tp.cap5buddy.logic.parser;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Stores mapping of prefixes to their respective arguments.
+ */
+public class ArgumentMap {
+
+    /** Prefixes mapped to their respective arguments**/
+    private final Map<Prefix, String> argumentMap = new HashMap<>();
+
+    /**
+     * Associates the specified argument value with {@code prefix} key in this map.
+     *
+     * @param prefix Prefix key with which the specified argument value is to be associated.
+     * @param prefixArgument String argument value to be associated with the specified prefix key.
+     */
+    public void put(Prefix prefix, String prefixArgument) {
+        argumentMap.put(prefix, prefixArgument);
+    }
+
+    /**
+     * Returns the value of {@code prefix}.
+     */
+    public Optional<String> getValue(Prefix prefix) {
+        Optional<String> prefixArgument = Optional.ofNullable(argumentMap.get(prefix));
+        return prefixArgument;
+    }
+
+    /**
+     * Returns true if all the prefixes in the argument are present in the hashmap
+     * and none of the prefixes contains empty {@code Optional} values.
+     *
+     * @param prefixes Array of prefixes.
+     * @return
+     */
+    public boolean arePrefixesPresent(Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> this.argumentMap.containsKey(prefix) &&
+                getValue(prefix).isPresent());
+    }
+
+    /**
+     * Returns the preamble (text before the first valid prefix). Trims any leading/trailing spaces.
+     */
+    public String getPreamble() {
+        return getValue(new Prefix("")).orElse("");
+    }
+}

--- a/src/main/java/tp/cap5buddy/logic/parser/ArgumentMap.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/ArgumentMap.java
@@ -39,8 +39,8 @@ public class ArgumentMap {
      * @return
      */
     public boolean arePrefixesPresent(Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> this.argumentMap.containsKey(prefix) &&
-                getValue(prefix).isPresent());
+        return Stream.of(prefixes).allMatch(prefix -> this.argumentMap.containsKey(prefix)
+                && getValue(prefix).isPresent());
     }
 
     /**

--- a/src/main/java/tp/cap5buddy/logic/parser/DeleteModuleParser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/DeleteModuleParser.java
@@ -17,9 +17,14 @@ public class DeleteModuleParser extends Parser {
      */
     @Override
     public Command parse(String userInput) throws ParseException {
-        Tokenizer token = new Tokenizer(userInput, PrefixList.MODULE_DELETE_PREFIX, PrefixList.MODULE_NEWNAME_PREFIX);
-        String[] parsedArguments = token.tokenize();
-        int position = Integer.parseInt(parsedArguments[0]);
+        Tokenizer token = new Tokenizer(userInput, PrefixList.MODULE_DELETE_PREFIX);
+        ArgumentMap argumentMap = token.tokenize();
+        if (!argumentMap.arePrefixesPresent(PrefixList.MODULE_DELETE_PREFIX)) {
+            String error = "Missing prefix arguments";
+            throw new ParseException(error);
+        }
+        int position = Integer.parseInt(argumentMap.getValue(PrefixList.MODULE_DELETE_PREFIX).get());
+
         return new DeleteModuleCommand(position);
     }
 }

--- a/src/main/java/tp/cap5buddy/logic/parser/EditModuleParser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/EditModuleParser.java
@@ -22,15 +22,19 @@ public class EditModuleParser extends Parser {
                 PrefixList.MODULE_NEWNAME_PREFIX,
                 PrefixList.MODULE_LINK_PREFIX
         );
-        String[] parsedArguments = token.tokenize();
-        String moduleName = parsedArguments[0];
+        ArgumentMap argumentMap = token.tokenize();
+        if (!argumentMap.arePrefixesPresent(PrefixList.MODULE_NAME_PREFIX,
+                PrefixList.MODULE_NEWNAME_PREFIX,
+                PrefixList.MODULE_LINK_PREFIX)) {
+            String error = "Missing prefix arguments";
+            throw new ParseException(error);
+        }
+        String moduleName = argumentMap.getValue(PrefixList.MODULE_NAME_PREFIX).get();
         EditModuleDescriptor editModuleDescriptor = new EditModuleDescriptor();
-        if (parsedArguments.length >= 2) {
-            editModuleDescriptor.setZoomLink(parsedArguments[2]);
-        }
-        if (parsedArguments.length >= 3) {
-            editModuleDescriptor.setName(parsedArguments[1]);
-        }
+        String zoomLink = argumentMap.getValue(PrefixList.MODULE_LINK_PREFIX).get();
+        editModuleDescriptor.setZoomLink(zoomLink);
+        String newModuleName = argumentMap.getValue(PrefixList.MODULE_NEWNAME_PREFIX).get();
+        editModuleDescriptor.setName(newModuleName);
         return new EditModuleCommand(moduleName, editModuleDescriptor);
     }
 }

--- a/src/main/java/tp/cap5buddy/logic/parser/Tokenizer.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/Tokenizer.java
@@ -3,8 +3,6 @@ package tp.cap5buddy.logic.parser;
 import java.util.ArrayList;
 import java.util.List;
 
-import seedu.address.logic.parser.ArgumentMultimap;
-import seedu.address.logic.parser.ArgumentTokenizer;
 import tp.cap5buddy.logic.parser.exception.ParseException;
 
 /**

--- a/src/main/java/tp/cap5buddy/logic/parser/Tokenizer.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/Tokenizer.java
@@ -3,14 +3,15 @@ package tp.cap5buddy.logic.parser;
 import java.util.ArrayList;
 import java.util.List;
 
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
 import tp.cap5buddy.logic.parser.exception.ParseException;
 
 /**
  * Represents the token of each user input.
  */
 public class Tokenizer {
-    private static final int SIZE = 6; // updates as the number of prefixes increases.
-    private final String[] words = new String[SIZE];
+
     private final String userInput;
     private final Prefix[] prefixes;
 
@@ -31,7 +32,7 @@ public class Tokenizer {
      * @return String array containing command arguments.
      * @throws ParseException If the user input could not be parsed.
      */
-    public String[] tokenize() throws ParseException {
+    public ArgumentMap tokenize() throws ParseException {
         List<PrefixPosition> prefixPositions = findAllPrefixPositions();
         return extractArguments(this.userInput, prefixPositions);
     }
@@ -94,15 +95,28 @@ public class Tokenizer {
      * @param prefixPositions Prefix positions.
      * @return String array containing the command arguments.
      */
-    private String[] extractArguments(String userInput, List<PrefixPosition> prefixPositions) {
-        String[] results = new String[SIZE];
+    private ArgumentMap extractArguments(String userInput, List<PrefixPosition> prefixPositions) {
+
+        // Sort by start position
+        prefixPositions.sort((prefix1, prefix2) -> prefix1.getPrefixIndex() - prefix2.getPrefixIndex());
+
+        // Insert a PrefixPosition to represent the preamble of the user input
+        PrefixPosition preambleMarker = new PrefixPosition(0, new Prefix(""));
+        prefixPositions.add(0, preambleMarker);
+
         PrefixPosition endPositionMarker = new PrefixPosition(userInput.length(), new Prefix(""));
         prefixPositions.add(endPositionMarker);
+
+        // Map prefixes to their argument values (if any)
+        ArgumentMap argumentMap = new ArgumentMap();
+
         for (int i = 0; i < prefixPositions.size() - 1; i++) {
-            String argument = extractArgument(userInput, prefixPositions.get(i), prefixPositions.get(i + 1));
-            results[i] = argument;
+            // Extract and store prefixes and their arguments
+            Prefix prefix = prefixPositions.get(i).getPrefix();
+            String prefixArgument = extractArgument(userInput, prefixPositions.get(i), prefixPositions.get(i + 1));
+            argumentMap.put(prefix, prefixArgument);
         }
-        return results;
+        return argumentMap;
     }
 
     /**
@@ -121,10 +135,6 @@ public class Tokenizer {
         int argumentIndex = currentPrefixPosition.getPrefixIndex() + prefix.getPrefix().length();
         String argument = userInput.substring(argumentIndex, nextPrefixPosition.getPrefixIndex());
         return argument.trim();
-    }
-
-    public String[] getWords() {
-        return this.words;
     }
 
 }

--- a/src/main/java/tp/cap5buddy/logic/parser/ViewModuleParser.java
+++ b/src/main/java/tp/cap5buddy/logic/parser/ViewModuleParser.java
@@ -17,8 +17,12 @@ public class ViewModuleParser extends Parser {
      */
     public Command parse(String userInput) throws ParseException {
         Tokenizer token = new Tokenizer(userInput, PrefixList.MODULE_VIEW_PREFIX);
-        String[] parsedArguments = token.tokenize();
-        String modName = parsedArguments[0];
+        ArgumentMap argumentMap = token.tokenize();
+        if (!argumentMap.arePrefixesPresent(PrefixList.MODULE_VIEW_PREFIX)) {
+            String error = "Missing prefix arguments";
+            throw new ParseException(error);
+        }
+        String modName = argumentMap.getValue(PrefixList.MODULE_VIEW_PREFIX).get();
         return new ViewModuleCommand(modName);
     }
 }


### PR DESCRIPTION
Fixes #170 

The current implementation of the tokenizer stores the parsed prefix arguments in a String array. This can make it unsuitable to fetch prefix arguments easily. This PR modifies the tokenizer to store the prefix arguments in a hashmap and provides methods to retrieve the prefix arguments.

The following classes were added:
1. ArgumentMap (to serve as a store of the parsed prefix arguments)

The relevant parser classes have been updated as well:
1. AddContactParser
2. AddModuleParser
3. AddZoomLinkParser
4. DeleteModuleParser
5. EditModuleParser
6. ViewModuleParser