### PR TITLE
TodoList : Implement command to list all tasks

### DIFF
--- a/src/main/java/seedu/address/logic/commands/todolistcommands/ListTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todolistcommands/ListTaskCommand.java
@@ -1,15 +1,23 @@
 package seedu.address.logic.commands.todolistcommands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
+
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
 public class ListTaskCommand extends Command {
-    public static final String COMMAND_WORD = "listtodo";
+    public static final String COMMAND_WORD = "listtask";
+
+    public static final String MESSAGE_SUCCESS = "Listed all tasks";
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return null;
+        requireNonNull(model);
+        model.updateFilteredTodoList(PREDICATE_SHOW_ALL_TASKS);
+        return new CommandResult(MESSAGE_SUCCESS);
     }
 
     @Override


### PR DESCRIPTION
Fixes #310 

This PR added the implementation to list all tasks.

1. File changes:
- ListTaskCommand class:
  - Change COMMAND_WORD from "listtodo" to "listtask".
  - Implement methods.
