### PR TITLE
Tests: Update tests for module parsers

### DIFF
--- a/src/main/java/seedu/address/logic/commands/modulelistcommands/EditModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/modulelistcommands/EditModuleCommand.java
@@ -62,7 +62,7 @@ public class EditModuleCommand extends Command {
         List<Module> lastShownList = model.getFilteredModuleList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_MODULE_DISPLAYED_INDEX);
         }
         Module module = lastShownList.get(index.getZeroBased());
         Module editedModule = createEditedModule(module, editModuleDescriptor);

--- a/src/main/java/seedu/address/logic/commands/modulelistcommands/EditModuleDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/modulelistcommands/EditModuleDescriptor.java
@@ -47,7 +47,7 @@ public class EditModuleDescriptor {
      * Returns true if at least one field is edited.
      */
     public boolean isAnyFieldEdited() {
-        return CollectionUtil.isAnyNonNull(moduleName, zoomLinks, modularCredits, gradePoint);
+        return CollectionUtil.isAnyNonNull(moduleName, zoomLinks, modularCredits, gradePoint, tags);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -216,7 +216,7 @@ public class ParserUtil {
     public static GradePoint parseGradePoint(String gradePoint) throws ParseException {
         double trimmedGradePoint;
         if (!GradePoint.isValidGradePoint(gradePoint)) {
-            throw new ParseException(Assignment.MESSAGE_ASSIGNMENT_RESULT_CONSTRAINTS);
+            throw new ParseException(GradePoint.MESSAGE_CONSTRAINTS);
         } else {
             trimmedGradePoint = Double.parseDouble(gradePoint.trim());
         }

--- a/src/main/java/seedu/address/logic/parser/modulelistparsers/EditModuleParser.java
+++ b/src/main/java/seedu/address/logic/parser/modulelistparsers/EditModuleParser.java
@@ -45,7 +45,7 @@ public class EditModuleParser implements Parser<EditModuleCommand> {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    EditTaskCommand.MESSAGE_USAGE), pe);
+                    EditModuleCommand.MESSAGE_USAGE), pe);
         }
 
         EditModuleDescriptor editModuleDescriptor = new EditModuleDescriptor();

--- a/src/main/java/seedu/address/logic/parser/modulelistparsers/EditModuleParser.java
+++ b/src/main/java/seedu/address/logic/parser/modulelistparsers/EditModuleParser.java
@@ -100,5 +100,4 @@ public class EditModuleParser implements Parser<EditModuleCommand> {
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/modulelistparsers/EditModuleParser.java
+++ b/src/main/java/seedu/address/logic/parser/modulelistparsers/EditModuleParser.java
@@ -16,7 +16,6 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.modulelistcommands.EditModuleCommand;
 import seedu.address.logic.commands.modulelistcommands.EditModuleDescriptor;
-import seedu.address.logic.commands.todolistcommands.EditTaskCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;

--- a/src/main/java/seedu/address/model/module/ModuleName.java
+++ b/src/main/java/seedu/address/model/module/ModuleName.java
@@ -16,7 +16,7 @@ public class ModuleName {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[A-Z]{2,2}[\\d]{4,4}\\D?";
+    public static final String VALIDATION_REGEX = "[A-Z]{2,3}[\\d]{4,4}\\D?";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/module/ModuleName.java
+++ b/src/main/java/seedu/address/model/module/ModuleName.java
@@ -16,7 +16,7 @@ public class ModuleName {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[A-Z]{2,2}[\\d]{4,4}\\D?";
 
     public final String fullName;
 
@@ -35,8 +35,7 @@ public class ModuleName {
      * Returns true if a given string is a valid name.
      */
     public static boolean isValidName(String test) {
-        //return test.matches(VALIDATION_REGEX);
-        return true;
+        return test.matches(VALIDATION_REGEX);
     }
 
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -46,6 +46,8 @@ public class CommandTestUtil {
 
     public static final String VALID_MODULENAME_CS2103T = "CS2103T";
     public static final String VALID_MODULENAME_ES2660 = "ES2660";
+    public static final String VALID_MODULELESSONTYPE_CS2103T = "Lecture";
+    public static final String VALID_MODULELESSONTYPE_ES2660 = "Tutorial";
     public static final String VALID_ZOOMLINK_CS2103T = "www.cs2103tzoom.us";
     public static final String VALID_ZOOMLINK_ES2660 = "www.es2660zoom.us";
     public static final double VALID_MC_4 = 4.0;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -48,8 +48,8 @@ public class CommandTestUtil {
     public static final String VALID_MODULENAME_ES2660 = "ES2660";
     public static final String VALID_MODULELESSONTYPE_CS2103T = "Lecture";
     public static final String VALID_MODULELESSONTYPE_ES2660 = "Tutorial";
-    public static final String VALID_ZOOMLINK_CS2103T = "www.cs2103tzoom.us";
-    public static final String VALID_ZOOMLINK_ES2660 = "www.es2660zoom.us";
+    public static final String VALID_ZOOMLINK_CS2103T = "https://nus-sg.zoom.us/cs2103t";
+    public static final String VALID_ZOOMLINK_ES2660 = "https://nus-sg.zoom.us/es2660";
     public static final double VALID_MC_4 = 4.0;
     public static final double VALID_MC_2 = 2.0;
     public static final double VALID_GRADEPOINT_4 = 4.0;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -52,6 +52,8 @@ public class CommandTestUtil {
     public static final String VALID_ZOOMLINK_ES2660 = "www.es2660zoom.us";
     public static final double VALID_MC_4 = 4.0;
     public static final double VALID_MC_2 = 2.0;
+    public static final double VALID_GRADEPOINT_4 = 4.0;
+    public static final double VALID_GRADEPOINT_5 = 5.0;
     public static final String VALID_TAG_LECTURE = "Lecture";
     public static final String VALID_TAG_TUTORIAL = "Tutorial";
 

--- a/src/test/java/seedu/address/logic/parser/AddModuleParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddModuleParserTest.java
@@ -1,130 +1,103 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-// import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MC_2;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MC_4;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULENAME_CS2103T;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULENAME_ES2660;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOMLINK_CS2103T;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOMLINK_ES2660;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULAR_CREDITS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ZOOM_LINK;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-// import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.modulelistcommands.AddModuleCommand;
 import seedu.address.logic.parser.modulelistparsers.AddModuleParser;
-//import seedu.address.model.module.ModularCredits;
-// import seedu.address.model.module.Module;
-//import seedu.address.model.module.ModuleName;
-//import seedu.address.model.module.ZoomLink;
-//import seedu.address.model.tag.Tag;
-// import seedu.address.testutil.ModuleBuilder;
+import seedu.address.model.module.ModularCredits;
+import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleName;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.ModuleBuilder;
 
 public class AddModuleParserTest {
     private static final String multipleMCs = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T
-            + " " + PREFIX_ZOOM_LINK + VALID_ZOOMLINK_CS2103T
             + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4
-            + " " + PREFIX_MODULAR_CREDITS + VALID_MC_2;
+            + " " + PREFIX_MODULAR_CREDITS + VALID_MC_2
+            + " " + PREFIX_TAG + VALID_TAG_LECTURE;
 
     private static final String multipleNames = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T
             + " " + PREFIX_NAME + VALID_MODULENAME_ES2660
-            + " " + PREFIX_ZOOM_LINK + VALID_ZOOMLINK_CS2103T
-            + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4;
-
-    private static final String multipleLinks = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T
-            + " " + PREFIX_ZOOM_LINK + VALID_ZOOMLINK_CS2103T
-            + " " + PREFIX_ZOOM_LINK + VALID_ZOOMLINK_ES2660
-            + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4;
+            + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4
+            + " " + PREFIX_TAG + VALID_TAG_LECTURE;
 
     private static final String validInput = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T
-            + " " + PREFIX_ZOOM_LINK + VALID_ZOOMLINK_CS2103T
+            + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4
+            + " " + PREFIX_TAG + VALID_TAG_LECTURE;
+
+    private static final String validInputNoTag = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T
             + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4;
+
+    private static final String validInputNoModularCredits = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T
+            + " " + PREFIX_TAG + VALID_TAG_LECTURE;
+
+    private static final String validInputOnlyName= " " + PREFIX_NAME + VALID_MODULENAME_CS2103T;
 
     private AddModuleParser parser = new AddModuleParser();
 
-    /*
     @Test
     public void parse_allFieldsPresent_success() {
-        // need to add tags into all of these tests.
         Module expectedModule = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T)
-                .withZoomLink(VALID_ZOOMLINK_CS2103T).withMC(VALID_MC_4).build();
+                .withMC(VALID_MC_4).withTag(VALID_TAG_LECTURE).build();
 
         assertParseSuccess(parser, validInput, new AddModuleCommand(expectedModule));
-
-        // multiple tags - all accepted
-        // Contact expectedPersonMultipleTags = new ContactBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-        //        .build();
-        // assertParseSuccess(parser, NAME_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-        //         + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedPersonMultipleTags));
-
     }
-     */
 
-    /*
+    @Test
+    public void parse_tagFieldAbsent_success() {
+        Module expectedModule = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T)
+                .withMC(VALID_MC_4).build();
+
+        assertParseSuccess(parser, validInputNoTag, new AddModuleCommand(expectedModule));
+    }
+
+    @Test
+    public void parse_modularCreditsFieldAbsent_success() {
+        Module expectedModule = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T)
+                .withTag(VALID_TAG_LECTURE).build();
+
+        assertParseSuccess(parser, validInputNoModularCredits, new AddModuleCommand(expectedModule));
+    }
+
+    @Test
+    public void parse_onlyNamePresent_success() {
+        Module expectedModule = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T).build();
+
+        assertParseSuccess(parser, validInputOnlyName, new AddModuleCommand(expectedModule));
+    }
+
     @Test
     public void parse_preambleWhiteSpace_success() {
         Module expectedModule = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T)
-                .withZoomLink(VALID_ZOOMLINK_CS2103T).withMC(VALID_MC_4).build();
+                .withMC(VALID_MC_4).withTag(VALID_TAG_LECTURE).build();
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + validInput,
                 new AddModuleCommand(expectedModule));
     }
-     */
 
-    /*
     @Test
     public void parse_multipleNames_success() {
         Module expectedModule = new ModuleBuilder().withName(VALID_MODULENAME_ES2660)
-                .withZoomLink(VALID_ZOOMLINK_CS2103T)
-                .withMC(VALID_MC_4)
-                .build();
+                .withMC(VALID_MC_4).withTag(VALID_TAG_LECTURE).build();
         assertParseSuccess(parser, multipleNames, new AddModuleCommand(expectedModule));
     }
-     */
 
-    /*
-    @Test
-    public void parse_multipleLinks_success() {
-        Module expectedModule = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T)
-                .withZoomLink(VALID_ZOOMLINK_ES2660)
-                .withMC(VALID_MC_4)
-                .build();
-        assertParseSuccess(parser, multipleLinks, new AddModuleCommand(expectedModule));
-    }
-     */
-
-    /*
     @Test
     public void parse_multipleMCs_success() {
         Module expectedModule = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T)
-                .withZoomLink(VALID_ZOOMLINK_CS2103T)
-                .withMC(VALID_MC_2)
-                .build();
+                .withMC(VALID_MC_2).withTag(VALID_TAG_LECTURE).build();
         assertParseSuccess(parser, multipleMCs, new AddModuleCommand(expectedModule));
-    }
-     */
-
-
-    @Test
-    public void parse_optionalFieldsMissing_success() {
-        // zero tags
-        // Contact expectedPerson = new ContactBuilder(AMY).withTags().build();
-
-        // assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
-        //         new AddCommand(expectedPerson));
-
     }
 
     @Test
     public void parse_compulsoryNameFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddModuleCommand.MESSAGE_USAGE);
-        String missingName = " " + PREFIX_ZOOM_LINK + VALID_ZOOMLINK_CS2103T
-                + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4;
-        // missing name prefix
+        String missingName = " " + PREFIX_MODULAR_CREDITS + VALID_MC_4 + " " + PREFIX_TAG + VALID_TAG_LECTURE;
         assertParseFailure(parser, missingName, expectedMessage);
     }
 
@@ -132,43 +105,36 @@ public class AddModuleParserTest {
     public void parse_compulsoryAllFieldsMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddModuleCommand.MESSAGE_USAGE);
         String missingAll = "";
-        // all prefixes missing
         assertParseFailure(parser, missingAll, expectedMessage);
     }
 
     @Test
     public void parse_invalidName_failure() {
-        //String invalidName = " " + PREFIX_NAME + "@123" + " " + PREFIX_ZOOM_LINK + "www.example.com";
-        // invalid name
-        //assertParseFailure(parser, invalidName, ModuleName.MESSAGE_CONSTRAINTS);
-    }
-
-    @Test
-    public void parse_invalidZoomLink_failure() {
-        //String invalidLink = " " + PREFIX_NAME + "CS2103T" + " " + PREFIX_ZOOM_LINK + "1234";
-        //assertParseFailure(parser, invalidLink, ZoomLink.MESSAGE_CONSTRAINTS);
+        String invalidName = " " + PREFIX_NAME + "@@@@@@@ " + PREFIX_MODULAR_CREDITS + VALID_MC_4
+                + " " + PREFIX_TAG + VALID_TAG_LECTURE;
+        assertParseFailure(parser, invalidName, ModuleName.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_invalidMC_failure() {
-        //String invalidMC = " " + PREFIX_NAME + "CS2103T"
-        //        + " " + PREFIX_ZOOM_LINK + "www.example.com"
-        //        + " " + PREFIX_MODULAR_CREDITS + "3.9";
-        //assertParseFailure(parser, invalidMC, ModularCredits.MESSAGE_CONSTRAINTS);
+        String invalidMC = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T + " " + PREFIX_MODULAR_CREDITS + "-2"
+                + " " + PREFIX_TAG + VALID_TAG_LECTURE;
+        assertParseFailure(parser, invalidMC, ModularCredits.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_invalidTags_failure() {
-        //String invalidTags = ""; // need to implement this.
-        //assertParseFailure(parser, invalidTags, Tag.MESSAGE_CONSTRAINTS);
+        String invalidTags = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T + " " + PREFIX_MODULAR_CREDITS + "-2"
+                + " " + PREFIX_TAG + "@#@#";
+        assertParseFailure(parser, invalidTags, Tag.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
-        String nonEmptyPreamble = "add " + PREFIX_NAME + "CS2103T"
-                + " " + PREFIX_ZOOM_LINK + "www.example.com";
-        assertParseFailure(parser, nonEmptyPreamble,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddModuleCommand.MESSAGE_USAGE));
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddModuleCommand.MESSAGE_USAGE);
+        String nonEmptyPreamble = "add " + PREFIX_NAME + VALID_MODULENAME_CS2103T + " " + PREFIX_MODULAR_CREDITS + "-2"
+                + " " + PREFIX_TAG + VALID_TAG_LECTURE;
+        assertParseFailure(parser, nonEmptyPreamble, expectedMessage);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/AddModuleParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddModuleParserTest.java
@@ -144,7 +144,7 @@ public class AddModuleParserTest {
 
     @Test
     public void parse_invalidTags_failure() {
-        String invalidTags = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T + " " + PREFIX_MODULAR_CREDITS + "-2"
+        String invalidTags = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4
                 + " " + PREFIX_TAG + "@#@#";
         assertParseFailure(parser, invalidTags, Tag.MESSAGE_CONSTRAINTS);
     }
@@ -152,8 +152,8 @@ public class AddModuleParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddModuleCommand.MESSAGE_USAGE);
-        String nonEmptyPreamble = "add " + PREFIX_NAME + VALID_MODULENAME_CS2103T + " " + PREFIX_MODULAR_CREDITS + "-2"
-                + " " + PREFIX_TAG + VALID_TAG_LECTURE;
+        String nonEmptyPreamble = "add " + PREFIX_NAME + VALID_MODULENAME_CS2103T + " " + PREFIX_MODULAR_CREDITS
+                + VALID_MC_4 + " " + PREFIX_TAG + VALID_TAG_LECTURE;
         assertParseFailure(parser, nonEmptyPreamble, expectedMessage);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddModuleParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddModuleParserTest.java
@@ -1,8 +1,16 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.*;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MC_2;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MC_4;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULENAME_CS2103T;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULENAME_ES2660;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_TUTORIAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULAR_CREDITS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -27,6 +35,11 @@ public class AddModuleParserTest {
             + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4
             + " " + PREFIX_TAG + VALID_TAG_LECTURE;
 
+    private static final String multipleTags = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T
+            + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4
+            + " " + PREFIX_TAG + VALID_TAG_LECTURE
+            + " " + PREFIX_TAG + VALID_TAG_TUTORIAL;
+
     private static final String validInput = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T
             + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4
             + " " + PREFIX_TAG + VALID_TAG_LECTURE;
@@ -37,7 +50,7 @@ public class AddModuleParserTest {
     private static final String validInputNoModularCredits = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T
             + " " + PREFIX_TAG + VALID_TAG_LECTURE;
 
-    private static final String validInputOnlyName= " " + PREFIX_NAME + VALID_MODULENAME_CS2103T;
+    private static final String validInputOnlyName = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T;
 
     private AddModuleParser parser = new AddModuleParser();
 
@@ -88,10 +101,17 @@ public class AddModuleParserTest {
     }
 
     @Test
-    public void parse_multipleMCs_success() {
+    public void parse_multipleModularCredits_success() {
         Module expectedModule = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T)
                 .withMC(VALID_MC_2).withTag(VALID_TAG_LECTURE).build();
         assertParseSuccess(parser, multipleMCs, new AddModuleCommand(expectedModule));
+    }
+
+    @Test
+    public void parse_multipleTags_success() {
+        Module expectedModule = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T)
+                .withMC(VALID_MC_4).withTag(VALID_TAG_TUTORIAL).withTag(VALID_TAG_LECTURE).build();
+        assertParseSuccess(parser, multipleTags, new AddModuleCommand(expectedModule));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditModuleParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditModuleParserTest.java
@@ -1,38 +1,45 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULENAME_CS2103T;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULENAME_ES2660;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOMLINK_ES2660;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ZOOM_LINK;
 //import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.modulelistcommands.AddModuleCommand;
 import seedu.address.logic.commands.modulelistcommands.EditModuleCommand;
 import seedu.address.logic.commands.modulelistcommands.EditModuleDescriptor;
 import seedu.address.logic.parser.modulelistparsers.EditModuleParser;
+import seedu.address.model.module.ModularCredits;
+import seedu.address.model.module.ModuleName;
+import seedu.address.model.module.grade.GradePoint;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditModuleDescriptorBuilder;
 
 public class EditModuleParserTest {
     private static final int INDEX = 1;
-    private static final String VALID_INPUT = " " + INDEX
-            + " " + PREFIX_NAME + VALID_MODULENAME_ES2660
-            + " " + PREFIX_ZOOM_LINK + VALID_ZOOMLINK_ES2660;
-
-    private static final String VALID_INPUT_NO_LINK = " " + INDEX
+    private static final String VALID_INPUT_EDIT_NAME = " " + INDEX
             + " " + PREFIX_NAME + VALID_MODULENAME_ES2660;
 
-    private static final String VALID_INPUT_NO_NAME = " " + INDEX
-            + " " + PREFIX_ZOOM_LINK + VALID_ZOOMLINK_ES2660;
+    private static final String VALID_INPUT_EDIT_TAG = " " + INDEX
+            + " " + PREFIX_TAG + VALID_TAG_LECTURE;
 
-    private static final String VALID_INPUT_REPEATED = " " + INDEX
-            + " " + PREFIX_NAME + VALID_MODULENAME_CS2103T
+    private static final String VALID_INPUT_EDIT_GRADEPOINT = " " + INDEX
+            + " " + PREFIX_GRADE_POINT + VALID_GRADEPOINT_4;
+
+    private static final String VALID_INPUT_EDIT_MC = " " + INDEX
+            + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4;
+
+    private static final String VALID_INPUT_ALL_FIELDS = " " + INDEX
             + " " + PREFIX_NAME + VALID_MODULENAME_ES2660
-            + " " + PREFIX_ZOOM_LINK + VALID_ZOOMLINK_ES2660;
+            + " " + PREFIX_TAG + VALID_TAG_LECTURE
+            + " " + PREFIX_MODULAR_CREDITS + VALID_GRADEPOINT_4
+            + " " + PREFIX_MODULAR_CREDITS + VALID_MC_4;
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditModuleCommand.MESSAGE_USAGE);
@@ -41,34 +48,46 @@ public class EditModuleParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withName(VALID_MODULENAME_ES2660)
-                .withZoomLink(VALID_ZOOMLINK_ES2660).build();
+        EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withName(VALID_MODULENAME_ES2660).
+                withGradePoint(VALID_GRADEPOINT_4).withMc(VALID_MC_4).withTags(VALID_TAG_LECTURE).build();
         EditModuleCommand expectedCommand = new EditModuleCommand(Index.fromOneBased(1), descriptor);
-        assertParseSuccess(parser, VALID_INPUT, expectedCommand);
+        assertParseSuccess(parser, VALID_INPUT_ALL_FIELDS, expectedCommand);
     }
 
     @Test
     public void parse_onlyNameSpecified_success() {
         EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withName(VALID_MODULENAME_ES2660).build();
         EditModuleCommand expectedCommand = new EditModuleCommand(Index.fromOneBased(1), descriptor);
-        assertParseSuccess(parser, VALID_INPUT_NO_LINK, expectedCommand);
+        assertParseSuccess(parser, VALID_INPUT_EDIT_NAME, expectedCommand);
     }
 
-    /*
     @Test
-    public void parse_onlyZoomLinkSpecified_success() {
-        EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withZoomLink(VALID_ZOOMLINK_ES2660).build();
+    public void parse_onlyTagSpecified_success() {
+        EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withTags(VALID_TAG_LECTURE).build();
         EditModuleCommand expectedCommand = new EditModuleCommand(Index.fromOneBased(1), descriptor);
-        assertParseSuccess(parser, VALID_INPUT_NO_NAME, expectedCommand);
+        assertParseSuccess(parser, VALID_INPUT_EDIT_TAG, expectedCommand);
     }
-    */
+
+    @Test
+    public void parse_onlyGradePointSpecified_success() {
+        EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withGradePoint(VALID_GRADEPOINT_4).build();
+        EditModuleCommand expectedCommand = new EditModuleCommand(Index.fromOneBased(1), descriptor);
+        assertParseSuccess(parser, VALID_INPUT_EDIT_GRADEPOINT, expectedCommand);
+    }
+
+    @Test
+    public void parse_onlyMCSpecified_success() {
+        EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withMc(VALID_MC_4).build();
+        EditModuleCommand expectedCommand = new EditModuleCommand(Index.fromOneBased(1), descriptor);
+        assertParseSuccess(parser, VALID_INPUT_EDIT_MC, expectedCommand);
+    }
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
         EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withName(VALID_MODULENAME_ES2660)
                 .withZoomLink(VALID_ZOOMLINK_ES2660).build();
         EditModuleCommand expectedCommand = new EditModuleCommand(Index.fromOneBased(1), descriptor);
-        assertParseSuccess(parser, VALID_INPUT_REPEATED, expectedCommand);
+        assertParseSuccess(parser, VALID_INPUT_EDIT_NAME, expectedCommand);
     }
 
     @Test
@@ -82,21 +101,61 @@ public class EditModuleParserTest {
     }
 
     @Test
-    public void parse_missingCompulsoryName_failure() {
-        //String missingCompulsoryName = " " + PREFIX_NAME + VALID_ZOOMLINK_ES2660;
-        //assertParseFailure(parser, missingCompulsoryName, MESSAGE_INVALID_FORMAT);
+    public void parse_missingIndex_failure() {
+        String missingIndex = " " + PREFIX_NAME + VALID_MODULENAME_ES2660;
+        EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withName(VALID_MODULENAME_ES2660).build();
+        assertParseFailure(parser, missingIndex, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_missingAllFields_failure() {
-        //String missingAll = "";
-        //assertParseFailure(parser, missingAll, MESSAGE_INVALID_FORMAT);
+        String missingFields = " ";
+        EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().build();
+        assertParseFailure(parser, missingFields, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
-    public void parse_invalidValue_failure() {
-        //String invalid = " " + PREFIX_EDIT_NAME + VALID_MODULENAME_CS2103T
-        //        + " " + PREFIX_NAME + "@123";
-        //assertParseFailure(parser, invalid, MESSAGE_INVALID_FORMAT);
+    public void parse_invalidIndex_failure() {
+        //String invalidIndex = " " + 100
+        //        + " " + PREFIX_NAME + VALID_MODULENAME_ES2660;
+        //EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withName(VALID_MODULENAME_ES2660).build();
+        //assertParseFailure(parser, invalidIndex, MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void parse_invalidName_failure() {
+        String invalidName = " " + 1
+                + " " + PREFIX_NAME + "@123";
+        assertParseFailure(parser, invalidName, ModuleName.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidTag_failure() {
+        String invalidTag = " " + 1
+                + " " + PREFIX_TAG + "@@@@";
+        assertParseFailure(parser, invalidTag, Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidGradePoint_failure() {
+        String invalidGradePoint = " " + 1
+                + " " + PREFIX_GRADE_POINT + "10";
+        assertParseFailure(parser, invalidGradePoint, GradePoint.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidMC_failure() {
+        String invalidMC = " " + 1
+                + " " + PREFIX_MODULAR_CREDITS + "aa";
+        assertParseFailure(parser, invalidMC, ModularCredits.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_multipleInvalidFields_failure() {
+        String invalidMC = " " + 1
+                + " " + PREFIX_NAME + "2020CS"
+                + " " + PREFIX_MODULAR_CREDITS + "aa";
+        //shows error message of name because name takes priority over modular credits.
+        assertParseFailure(parser, invalidMC, ModuleName.MESSAGE_CONSTRAINTS);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditModuleParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditModuleParserTest.java
@@ -1,17 +1,21 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-//import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.commands.CommandTestUtil.*;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GRADEPOINT_4;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MC_4;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULENAME_ES2660;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOMLINK_ES2660;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GRADE_POINT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULAR_CREDITS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.modulelistcommands.AddModuleCommand;
 import seedu.address.logic.commands.modulelistcommands.EditModuleCommand;
 import seedu.address.logic.commands.modulelistcommands.EditModuleDescriptor;
 import seedu.address.logic.parser.modulelistparsers.EditModuleParser;
@@ -48,8 +52,8 @@ public class EditModuleParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withName(VALID_MODULENAME_ES2660).
-                withGradePoint(VALID_GRADEPOINT_4).withMc(VALID_MC_4).withTags(VALID_TAG_LECTURE).build();
+        EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withName(VALID_MODULENAME_ES2660)
+                .withGradePoint(VALID_GRADEPOINT_4).withMc(VALID_MC_4).withTags(VALID_TAG_LECTURE).build();
         EditModuleCommand expectedCommand = new EditModuleCommand(Index.fromOneBased(1), descriptor);
         assertParseSuccess(parser, VALID_INPUT_ALL_FIELDS, expectedCommand);
     }
@@ -76,7 +80,7 @@ public class EditModuleParserTest {
     }
 
     @Test
-    public void parse_onlyMCSpecified_success() {
+    public void parse_onlyMcSpecified_success() {
         EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder().withMc(VALID_MC_4).build();
         EditModuleCommand expectedCommand = new EditModuleCommand(Index.fromOneBased(1), descriptor);
         assertParseSuccess(parser, VALID_INPUT_EDIT_MC, expectedCommand);

--- a/src/test/java/seedu/address/testutil/EditModuleDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditModuleDescriptorBuilder.java
@@ -1,17 +1,13 @@
 package seedu.address.testutil;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import seedu.address.logic.commands.modulelistcommands.EditModuleDescriptor;
 import seedu.address.model.module.ModularCredits;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleName;
-// import seedu.address.model.module.ZoomLink;
-import seedu.address.model.module.ZoomLink;
 import seedu.address.model.module.grade.GradePoint;
-import seedu.address.model.module.grade.GradeTracker;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/test/java/seedu/address/testutil/EditModuleDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditModuleDescriptorBuilder.java
@@ -1,5 +1,7 @@
 package seedu.address.testutil;
 
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import seedu.address.logic.commands.modulelistcommands.EditModuleDescriptor;
@@ -7,6 +9,9 @@ import seedu.address.model.module.ModularCredits;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleName;
 // import seedu.address.model.module.ZoomLink;
+import seedu.address.model.module.ZoomLink;
+import seedu.address.model.module.grade.GradePoint;
+import seedu.address.model.module.grade.GradeTracker;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -32,6 +37,9 @@ public class EditModuleDescriptorBuilder {
         descriptor.setModuleName(module.getName());
         // descriptor.setZoomLink(module.getLink());
         descriptor.setModularCredits(module.getModularCredits());
+        if (module.getGradeTracker().getGradePoint().isPresent()) {
+            descriptor.setGradePoint(module.getGradeTracker().getGradePoint().get());
+        }
         descriptor.setTags(module.getTags());
     }
 
@@ -62,8 +70,17 @@ public class EditModuleDescriptorBuilder {
     /**
      * Sets the {@code Tag} of the {@code EditModuleDescriptor} that we are building.
      */
-    public EditModuleDescriptorBuilder withTags(Set<Tag> tags) {
-        descriptor.setTags(tags);
+    public EditModuleDescriptorBuilder withTags(String tag) {
+        Set<Tag> updatedTag = new HashSet<Tag>();
+        updatedTag.add(new Tag(tag));
+        return this;
+    }
+
+    /**
+     * Sets the {@code GradePoint} of the {@code EditModuleDescriptor} that we are building.
+     */
+    public EditModuleDescriptorBuilder withGradePoint(double gradePoint) {
+        descriptor.setGradePoint(new GradePoint(gradePoint));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/address/testutil/ModuleBuilder.java
@@ -5,6 +5,12 @@ import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleName;
 import seedu.address.model.module.ZoomLink;
 import seedu.address.model.module.grade.GradeTracker;
+import seedu.address.model.tag.Tag;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * A utility class to help with building Module objects.
@@ -12,22 +18,26 @@ import seedu.address.model.module.grade.GradeTracker;
 public class ModuleBuilder {
 
     public static final String DEFAULT_MODULENAME = "CS2103T";
+    public static final String DEFAULT_MODULELESSONTYPE = "tutorial";
     public static final String DEFAULT_ZOOMLINK = "www.zoom.us";
     public static final double DEFAULT_MODULARCREDITS = 4.0;
+    public static final String DEFAULT_TAGS = "online";
 
     private ModuleName moduleName;
-    private ZoomLink zoomLink;
+    private Map<String, ZoomLink> zoomLinkMap;
     private ModularCredits modularCredits;
     private GradeTracker gradeTracker;
+    private Set<Tag> tag;
 
     /**
      * Creates a {@code ModuleBuilder} with the default details.
      */
     public ModuleBuilder() {
         moduleName = new ModuleName(DEFAULT_MODULENAME);
-        zoomLink = new ZoomLink(DEFAULT_ZOOMLINK);
+        zoomLinkMap = new HashMap<String, ZoomLink>();
         modularCredits = new ModularCredits(DEFAULT_MODULARCREDITS);
         gradeTracker = new GradeTracker();
+        tag = new HashSet<Tag>();
     }
 
     /**
@@ -46,10 +56,11 @@ public class ModuleBuilder {
     }
 
     /**
-     * Sets the {@code ZoomLink} of the {@code Module} that we are building.
+     * Adds the {@code ZoomLink} to the {@code Module} that we are building.
      */
-    public ModuleBuilder withZoomLink(String zoomLink) {
-        this.zoomLink = new ZoomLink(zoomLink);
+    public ModuleBuilder withZoomLink(String moduleLessonType, String zoomLink) {
+        Map<String, ZoomLink> updatedLinks = new HashMap<>(this.zoomLinkMap);
+        updatedLinks.put(moduleLessonType, new ZoomLink(zoomLink));
         return this;
     }
 
@@ -62,13 +73,21 @@ public class ModuleBuilder {
     }
 
     /**
+     * Adds the {@code Tag} to the {@code Module} that we are building.
+     */
+    public ModuleBuilder withTag(String tag) {
+        Set<Tag> updatedTag = new HashSet<Tag>(this.tag);
+        updatedTag.add(new Tag(tag));
+        return this;
+    }
+
+    /**
      * Builds the module.
      *
      * @return a module
      */
     public Module build() {
-        // return new Module(moduleName, zoomLink, modularCredits);
-        return null;
+        return new Module(moduleName, zoomLinkMap, gradeTracker, tag, modularCredits);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/address/testutil/ModuleBuilder.java
@@ -1,16 +1,16 @@
 package seedu.address.testutil;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import seedu.address.model.module.ModularCredits;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleName;
 import seedu.address.model.module.ZoomLink;
 import seedu.address.model.module.grade.GradeTracker;
 import seedu.address.model.tag.Tag;
-
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * A utility class to help with building Module objects.
@@ -21,7 +21,7 @@ public class ModuleBuilder {
     public static final String DEFAULT_MODULELESSONTYPE = "tutorial";
     public static final String DEFAULT_ZOOMLINK = "www.zoom.us";
     public static final double DEFAULT_MODULARCREDITS = 4.0;
-    public static final String DEFAULT_TAGS = "online";
+    public static final String DEFAULT_TAGS = "";
 
     private ModuleName moduleName;
     private Map<String, ZoomLink> zoomLinkMap;

--- a/src/test/java/seedu/address/testutil/TypicalModules.java
+++ b/src/test/java/seedu/address/testutil/TypicalModules.java
@@ -1,13 +1,18 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULELESSONTYPE_CS2103T;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULELESSONTYPE_ES2660;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULENAME_CS2103T;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULENAME_ES2660;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOMLINK_CS2103T;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOMLINK_ES2660;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.ModuleList;
 import seedu.address.model.module.Module;
-
-import static seedu.address.logic.commands.CommandTestUtil.*;
 
 /**
  * A utility class containing a list of {@code Module} objects to be used in tests.
@@ -17,19 +22,19 @@ public class TypicalModules {
     public static final Module CS2030 = new ModuleBuilder().withName("CS2030")
         .withZoomLink("Lecture", "www.zoom.us").build();
     public static final Module CS2101 = new ModuleBuilder().withName("CS2101")
-        .withZoomLink("Lecture","www.zoom.us").build();
+        .withZoomLink("Lecture", "www.zoom.us").build();
     public static final Module CS2105 = new ModuleBuilder().withName("CS2105")
-        .withZoomLink("Lecture","www.zoom.us").build();
+        .withZoomLink("Lecture", "www.zoom.us").build();
     public static final Module CS1101S = new ModuleBuilder().withName("CS1101S")
-        .withZoomLink("Lecture","www.zoom.us").build();
+        .withZoomLink("Lecture", "www.zoom.us").build();
     public static final Module IS1103 = new ModuleBuilder().withName("IS1103")
-        .withZoomLink("Lecture","www.zoom.us").build();
+        .withZoomLink("Lecture", "www.zoom.us").build();
 
     // Manually added
     public static final Module CS1231S = new ModuleBuilder().withName("CS1231S")
-        .withZoomLink("Lecture","www.zoom.us").build();
+        .withZoomLink("Lecture", "www.zoom.us").build();
     public static final Module MA1101R = new ModuleBuilder().withName("MA1101R")
-        .withZoomLink("Lecture","www.zoom.us").build();
+        .withZoomLink("Lecture", "www.zoom.us").build();
 
     // Manually added - Modules's details found in {@code CommandTestUtil}
     public static final Module CS2103 = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T)

--- a/src/test/java/seedu/address/testutil/TypicalModules.java
+++ b/src/test/java/seedu/address/testutil/TypicalModules.java
@@ -20,21 +20,21 @@ import seedu.address.model.module.Module;
 public class TypicalModules {
 
     public static final Module CS2030 = new ModuleBuilder().withName("CS2030")
-        .withZoomLink("Lecture", "www.zoom.us").build();
+        .withZoomLink("Lecture", "https://nus-sg.zoom.us/").build();
     public static final Module CS2101 = new ModuleBuilder().withName("CS2101")
-        .withZoomLink("Lecture", "www.zoom.us").build();
+        .withZoomLink("Lecture", "https://nus-sg.zoom.us/").build();
     public static final Module CS2105 = new ModuleBuilder().withName("CS2105")
-        .withZoomLink("Lecture", "www.zoom.us").build();
+        .withZoomLink("Lecture", "https://nus-sg.zoom.us/").build();
     public static final Module CS1101S = new ModuleBuilder().withName("CS1101S")
-        .withZoomLink("Lecture", "www.zoom.us").build();
+        .withZoomLink("Lecture", "https://nus-sg.zoom.us/").build();
     public static final Module IS1103 = new ModuleBuilder().withName("IS1103")
-        .withZoomLink("Lecture", "www.zoom.us").build();
+        .withZoomLink("Lecture", "https://nus-sg.zoom.us/").build();
 
     // Manually added
     public static final Module CS1231S = new ModuleBuilder().withName("CS1231S")
-        .withZoomLink("Lecture", "www.zoom.us").build();
+        .withZoomLink("Lecture", "https://nus-sg.zoom.us/").build();
     public static final Module MA1101R = new ModuleBuilder().withName("MA1101R")
-        .withZoomLink("Lecture", "www.zoom.us").build();
+        .withZoomLink("Lecture", "https://nus-sg.zoom.us/").build();
 
     // Manually added - Modules's details found in {@code CommandTestUtil}
     public static final Module CS2103 = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T)

--- a/src/test/java/seedu/address/testutil/TypicalModules.java
+++ b/src/test/java/seedu/address/testutil/TypicalModules.java
@@ -1,10 +1,5 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULENAME_CS2103T;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULENAME_ES2660;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOMLINK_CS2103T;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOMLINK_ES2660;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -12,33 +7,35 @@ import java.util.List;
 import seedu.address.model.ModuleList;
 import seedu.address.model.module.Module;
 
+import static seedu.address.logic.commands.CommandTestUtil.*;
+
 /**
  * A utility class containing a list of {@code Module} objects to be used in tests.
  */
 public class TypicalModules {
 
     public static final Module CS2030 = new ModuleBuilder().withName("CS2030")
-        .withZoomLink("www.zoom.us").build();
+        .withZoomLink("Lecture", "www.zoom.us").build();
     public static final Module CS2101 = new ModuleBuilder().withName("CS2101")
-        .withZoomLink("www.zoom.us").build();
+        .withZoomLink("Lecture","www.zoom.us").build();
     public static final Module CS2105 = new ModuleBuilder().withName("CS2105")
-        .withZoomLink("www.zoom.us").build();
+        .withZoomLink("Lecture","www.zoom.us").build();
     public static final Module CS1101S = new ModuleBuilder().withName("CS1101S")
-        .withZoomLink("www.zoom.us").build();
+        .withZoomLink("Lecture","www.zoom.us").build();
     public static final Module IS1103 = new ModuleBuilder().withName("IS1103")
-        .withZoomLink("www.zoom.us").build();
+        .withZoomLink("Lecture","www.zoom.us").build();
 
     // Manually added
     public static final Module CS1231S = new ModuleBuilder().withName("CS1231S")
-        .withZoomLink("www.zoom.us").build();
+        .withZoomLink("Lecture","www.zoom.us").build();
     public static final Module MA1101R = new ModuleBuilder().withName("MA1101R")
-        .withZoomLink("www.zoom.us").build();
+        .withZoomLink("Lecture","www.zoom.us").build();
 
     // Manually added - Modules's details found in {@code CommandTestUtil}
     public static final Module CS2103 = new ModuleBuilder().withName(VALID_MODULENAME_CS2103T)
-        .withZoomLink(VALID_ZOOMLINK_CS2103T).build();
+        .withZoomLink(VALID_MODULELESSONTYPE_CS2103T, VALID_ZOOMLINK_CS2103T).build();
     public static final Module ES2660 = new ModuleBuilder().withName(VALID_MODULENAME_ES2660)
-        .withZoomLink(VALID_ZOOMLINK_ES2660).build();
+        .withZoomLink(VALID_MODULELESSONTYPE_ES2660, VALID_ZOOMLINK_ES2660).build();
 
     private TypicalModules() {} // prevents instantiation
 


### PR DESCRIPTION
Found errors during testing that I have fixed to the best of my ability.
Updated EditModule command to accept only tags to edit as well.
Fixed Editmodule gradepoint producing wrong invalid command output.
Updated Validation REGEX for fields that were not previously tested.

Testing could not be done for addmodule/editmodule with zoom links as current commands are not updated for the newly implemented hashmapped zoom links yet.

fixes #253 