### PR TITLE
Bug: Fix blank module lesson argument when adding a zoom link to a module and missing whitespaces in message constraints

### DIFF
--- a/src/main/java/seedu/address/logic/commands/modulelistcommands/AddZoomDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/modulelistcommands/AddZoomDescriptor.java
@@ -1,16 +1,17 @@
 package seedu.address.logic.commands.modulelistcommands;
 
+import seedu.address.model.module.ModuleLesson;
 import seedu.address.model.module.ZoomLink;
 
 /**
- * Stores the details of the zoom link to be added to a module.
+ * Stores the details of the zoom link to be added to a module and the lesson the link belongs to.
  */
 public class AddZoomDescriptor {
 
     /** ZoomLink object that contains the zoom link to be added. */
     private ZoomLink zoomLink;
-    /** String containing the details of the module lesson which the zoom link belongs to. */
-    private String moduleLessonType;
+    /** ModuleLesson object containing the details of the module lesson which the zoom link belongs to. */
+    private ModuleLesson moduleLesson;
 
     public AddZoomDescriptor() {}
 
@@ -19,7 +20,7 @@ public class AddZoomDescriptor {
      */
     public AddZoomDescriptor(AddZoomDescriptor toCopy) {
         setLink(toCopy.getZoomLink());
-        setModuleLessonType(toCopy.getModuleLessonType());
+        setModuleLesson(toCopy.getModuleLesson());
     }
 
     public void setLink(ZoomLink zoomLink) {
@@ -30,12 +31,12 @@ public class AddZoomDescriptor {
         return this.zoomLink;
     }
 
-    public void setModuleLessonType(String moduleLessonType) {
-        this.moduleLessonType = moduleLessonType;
+    public void setModuleLesson(ModuleLesson moduleLesson) {
+        this.moduleLesson = moduleLesson;
     }
 
-    public String getModuleLessonType() {
-        return this.moduleLessonType;
+    public ModuleLesson getModuleLesson() {
+        return this.moduleLesson;
     }
 
     @Override
@@ -55,7 +56,7 @@ public class AddZoomDescriptor {
         AddZoomDescriptor descriptor = (AddZoomDescriptor) other;
 
         return getZoomLink().equals(descriptor.getZoomLink())
-                && getModuleLessonType().equals(descriptor.getModuleLessonType());
+                && getModuleLesson().equals(descriptor.getModuleLesson());
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/modulelistcommands/AddZoomLinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/modulelistcommands/AddZoomLinkCommand.java
@@ -29,8 +29,8 @@ public class AddZoomLinkCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds a zoom link for a specific lesson to the module. "
             + "Parameters: " + "INDEX (must be a positive integer) "
-            + PREFIX_NAME + "MODULE LESSON TYPE"
-            + PREFIX_ZOOM_LINK + "ZOOM LINK "
+            + PREFIX_NAME + "MODULE_LESSON "
+            + PREFIX_ZOOM_LINK + "ZOOM_LINK "
             + "Example: " + COMMAND_WORD + " "
             + "1 " + PREFIX_NAME + "lecture "
             + PREFIX_ZOOM_LINK + "https://nus-sg.zoom.us/j/uasoihd637bf";

--- a/src/main/java/seedu/address/logic/commands/modulelistcommands/AddZoomLinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/modulelistcommands/AddZoomLinkCommand.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleLesson;
 import seedu.address.model.module.ZoomLink;
 
 /**
@@ -31,7 +32,7 @@ public class AddZoomLinkCommand extends Command {
             + PREFIX_NAME + "MODULE LESSON TYPE"
             + PREFIX_ZOOM_LINK + "ZOOM LINK "
             + "Example: " + COMMAND_WORD + " "
-            + "1" + PREFIX_NAME + "lecture"
+            + "1 " + PREFIX_NAME + "lecture "
             + PREFIX_ZOOM_LINK + "https://nus-sg.zoom.us/j/uasoihd637bf";
 
     public static final String MESSAGE_ADD_ZOOM_SUCCESS = "Added Zoom Link: %1$s";
@@ -64,10 +65,10 @@ public class AddZoomLinkCommand extends Command {
         }
 
         ZoomLink zoomLink = descriptor.getZoomLink();
-        String moduleLessonType = descriptor.getModuleLessonType();
+        ModuleLesson moduleLesson = descriptor.getModuleLesson();
 
         Module moduleToAddLink = lastShownList.get(targetIndex.getZeroBased());
-        Module updatedModule = moduleToAddLink.addZoomLink(moduleLessonType, zoomLink);
+        Module updatedModule = moduleToAddLink.addZoomLink(moduleLesson, zoomLink);
 
         model.setModule(moduleToAddLink, updatedModule);
         logger.info("Zoom link added to the module");

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -21,6 +21,7 @@ import seedu.address.model.contact.Telegram;
 import seedu.address.model.event.EventName;
 import seedu.address.model.event.EventTime;
 import seedu.address.model.module.ModularCredits;
+import seedu.address.model.module.ModuleLesson;
 import seedu.address.model.module.ModuleName;
 import seedu.address.model.module.ZoomLink;
 import seedu.address.model.module.grade.Assignment;
@@ -178,6 +179,21 @@ public class ParserUtil {
             throw new ParseException(ZoomLink.MESSAGE_CONSTRAINTS);
         }
         return new ZoomLink(trimmedZoomLink);
+    }
+
+    /**
+     * Parses a {@code String lesson} into a {@code ModuleLesson}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code lesson} is invalid.
+     */
+    public static ModuleLesson parseModuleLesson(String lesson) throws ParseException {
+        requireNonNull(lesson);
+        String trimmedLesson = lesson.trim();
+        if (!ModuleLesson.isValidLesson(trimmedLesson)) {
+            throw new ParseException(ModuleLesson.MESSAGE_CONSTRAINTS);
+        }
+        return new ModuleLesson(trimmedLesson);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/modulelistparsers/AddZoomLinkParser.java
+++ b/src/main/java/seedu/address/logic/parser/modulelistparsers/AddZoomLinkParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.ModuleLesson;
 import seedu.address.model.module.ZoomLink;
 
 /**
@@ -40,10 +41,11 @@ public class AddZoomLinkParser implements Parser<AddZoomLinkCommand> {
 
         Index moduleIndex;
         ZoomLink zoomLink;
-        String moduleLessonType = argMultimap.getValue(PREFIX_NAME).get();
+        ModuleLesson lesson;
 
         try {
             moduleIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+            lesson = ParserUtil.parseModuleLesson(argMultimap.getValue(PREFIX_NAME).get());
             zoomLink = ParserUtil.parseZoomLink(argMultimap.getValue(PREFIX_ZOOM_LINK).get());
         } catch (ParseException ex) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -52,7 +54,7 @@ public class AddZoomLinkParser implements Parser<AddZoomLinkCommand> {
 
         AddZoomDescriptor descriptor = new AddZoomDescriptor();
         descriptor.setLink(zoomLink);
-        descriptor.setModuleLessonType(moduleLessonType);
+        descriptor.setModuleLesson(lesson);
 
         return new AddZoomLinkCommand(moduleIndex, descriptor);
     }

--- a/src/main/java/seedu/address/model/contact/ContactComparatorByName.java
+++ b/src/main/java/seedu/address/model/contact/ContactComparatorByName.java
@@ -17,7 +17,7 @@ public class ContactComparatorByName implements Comparator<Contact> {
      */
     @Override
     public int compare(Contact contact, Contact otherContact) {
-        int value = contact.getName().fullName.compareToIgnoreCase(otherContact.getName().fullName);
+        int value = contact.getName().getName().compareToIgnoreCase(otherContact.getName().getName());
         if (value > 0) {
             return 1;
         } else if (value == 0) {

--- a/src/main/java/seedu/address/model/contact/ContactName.java
+++ b/src/main/java/seedu/address/model/contact/ContactName.java
@@ -18,7 +18,7 @@ public class ContactName {
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
-    public final String fullName;
+    private final String fullName;
 
     /**
      * Constructs a {@code Name}.
@@ -32,12 +32,15 @@ public class ContactName {
     }
 
     /**
-     * Returns true if a given string is a valid name.
+     * Returns true if a given string is a valid contact name.
      */
     public static boolean isValidName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
 
+    public String getName() {
+        return this.fullName;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/contact/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/contact/NameContainsKeywordsPredicate.java
@@ -18,7 +18,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Contact> {
     @Override
     public boolean test(Contact contact) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(contact.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(contact.getName().getName(), keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -194,27 +194,27 @@ public class Module {
     }
 
     /**
-     * Adds the zoom link for this module.
+     * Adds the zoom link to this module for a specific lesson.
      *
-     * @param key name to indicate the zoom link
-     * @param link zoom link
-     * @return module containing the updated zoom links
+     * @param lesson Module lesson which the zoom link belongs to.
+     * @param link Zoom link.
+     * @return Module containing the updated zoom links.
      */
-    public Module addZoomLink(String key, ZoomLink link) {
+    public Module addZoomLink(ModuleLesson lesson, ZoomLink link) {
         Map<String, ZoomLink> updatedLinks = new HashMap<>(this.zoomLinks);
-        updatedLinks.put(key, link);
+        // updatedLinks.put(lesson, link);
         return new Module(this.name, updatedLinks, this.gradeTracker, this.tags, this.modularCredits);
     }
 
     /**
      * Deletes the zoom link based on the specified key.
      *
-     * @param key name of the zoom link to be deleted
+     * @param lesson Module lesson which the zoom link to be deleted belongs to.
      * @return module containing the updated zoom links
      */
-    public Module deleteZoomLink(String key) {
+    public Module deleteZoomLink(ModuleLesson lesson) {
         Map<String, ZoomLink> updatedLinks = new HashMap<>(this.zoomLinks);
-        updatedLinks.remove(key);
+        // updatedLinks.remove(key);
         return new Module(this.name, updatedLinks, this.gradeTracker, this.tags, this.modularCredits);
     }
 

--- a/src/main/java/seedu/address/model/module/ModuleLesson.java
+++ b/src/main/java/seedu/address/model/module/ModuleLesson.java
@@ -1,0 +1,60 @@
+package seedu.address.model.module;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a lesson of a module.
+ * Guarantees: immutable; is valid as declared in {@link #isValidLesson(String)}
+ */
+public class ModuleLesson {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Lesson name should only contain alphanumeric characters and spaces, and it should not be blank.";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    private final String lessonName;
+
+    /**
+     * Creates and initialises a new {@code Lesson} object with a {@code lessonName}.
+     *
+     * @param lessonName String containing the lesson name.
+     */
+    public ModuleLesson(String lessonName) {
+        requireNonNull(lessonName);
+        checkArgument(isValidLesson(lessonName), MESSAGE_CONSTRAINTS);
+        this.lessonName = lessonName;
+    }
+
+    public String getLesson() {
+        return this.lessonName;
+    }
+
+    /**
+     * Returns true if the given String is a valid Lesson.
+     *
+     * @param lesson String containing the lesson name.
+     * @return True if the lesson is valid, false otherwise.
+     */
+    public static boolean isValidLesson(String lesson) {
+        return lesson.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return this.lessonName;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ModuleLesson // instanceof handles nulls
+                && lessonName.equals(((ModuleLesson) other).lessonName)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/module/ZoomLink.java
+++ b/src/main/java/seedu/address/model/module/ZoomLink.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Module's Zoom Link in the Module List.
+ * Represents a Zoom Link for a module in the Module List.
  * Guarantees: immutable; is valid as declared in {@link #isValidZoomLink(String)}
  */
 public class ZoomLink {
@@ -14,41 +14,24 @@ public class ZoomLink {
     public static final String ZOOM_LINK_PATH = "[a-zA-Z0-9?=/]+";
     public static final String VALIDATION_REGEX = ZOOM_LINK_DOMAIN + ZOOM_LINK_PATH;
 
-    public final String value;
+    private final String link;
 
     /**
-     * Constructs an {@code Email}.
+     * Constructs an {@code ZoomLink}.
      *
-     * @param zoomLink A valid email address.
+     * @param zoomLink A valid zoom link.
      */
     public ZoomLink(String zoomLink) {
         requireNonNull(zoomLink);
         checkArgument(isValidZoomLink(zoomLink), MESSAGE_CONSTRAINTS);
-        value = zoomLink;
+        link = zoomLink;
     }
 
     /**
-     * Returns if a given string is a valid email.
+     * Returns true if the given zoom link is a valid zoom link.
      */
-    public static boolean isValidZoomLink(String test) {
-        return test.matches(VALIDATION_REGEX);
-    }
-
-    @Override
-    public String toString() {
-        return value;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof ZoomLink // instanceof handles nulls
-                && value.equals(((ZoomLink) other).value)); // state check
-    }
-
-    @Override
-    public int hashCode() {
-        return value.hashCode();
+    public static boolean isValidZoomLink(String zoomLink) {
+        return zoomLink.matches(VALIDATION_REGEX);
     }
 
     /**
@@ -56,7 +39,24 @@ public class ZoomLink {
      * @return String zoom link.
      */
     public String getLink() {
-        return this.value;
+        return this.link;
+    }
+
+    @Override
+    public String toString() {
+        return this.link;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ZoomLink // instanceof handles nulls
+                && link.equals(((ZoomLink) other).link)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return link.hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/module/ZoomLink.java
+++ b/src/main/java/seedu/address/model/module/ZoomLink.java
@@ -9,7 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class ZoomLink {
 
-    public static final String MESSAGE_CONSTRAINTS = "Zoom links should be of the format www.nus-sg.zoom.us/[path]";
+    public static final String MESSAGE_CONSTRAINTS = "Zoom links should belong to the NUS domain"
+            + " and adhere to the format https://nus-sg.zoom.us/[path]";
     public static final String ZOOM_LINK_DOMAIN = "https://nus-sg.zoom.us/";
     public static final String ZOOM_LINK_PATH = "[a-zA-Z0-9?=/]+";
     public static final String VALIDATION_REGEX = ZOOM_LINK_DOMAIN + ZOOM_LINK_PATH;

--- a/src/main/java/seedu/address/storage/JsonAdaptedContact.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedContact.java
@@ -51,7 +51,7 @@ public class JsonAdaptedContact {
      * Converts a given {@code Contact} into this class for Jackson use.
      */
     public JsonAdaptedContact(Contact source) {
-        name = source.getName().fullName;
+        name = source.getName().getName();
         email = source.getEmail().value;
 
         if (source.getTelegram().isPresent()) {

--- a/src/main/java/seedu/address/ui/ContactCard.java
+++ b/src/main/java/seedu/address/ui/ContactCard.java
@@ -41,7 +41,7 @@ public class ContactCard extends UiPart<Region> {
         super(FXML);
         this.contact = contact;
         id.setText(displayedIndex + ". ");
-        name.setText(contact.getName().fullName);
+        name.setText(contact.getName().getName());
         email.setText(contact.getEmail().value);
         isImportant.setText(contact.getIsImportantForUi());
         if (contact.getTelegram().isPresent()) {

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -27,7 +27,7 @@ public class PersonUtil {
      */
     public static String getPersonDetails(Contact person) {
         StringBuilder sb = new StringBuilder();
-        sb.append(PREFIX_NAME + person.getName().fullName + " ");
+        sb.append(PREFIX_NAME + person.getName().getName() + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")


### PR DESCRIPTION
This PR:
 * Fixes #521 (PE dry run)
 * Fixes #529 (PE dry run)
 * Fixes #540 

Details of the bug can be found at: #540 

The current hashmap for ZoomLink storage maps a String, containing the module lesson which the zoom link belongs to, to the ZoomLink object.

This makes it difficult to perform checks on the module lesson argument
provided by users to validate them.

Let's
 * Create a new ModuleLesson class to encapsulate details and methods
   relating to a module lesson
 * Modify the hashmap into a hashmap that maps a ModuleLesson object to
   the corresponding zoom link
 * Modify the AddZoomLinkCommand and AddZoomLinkParser accordingly
