### PR TITLE
Modify EditContactCommand to allow deleting of telegram field

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -697,11 +697,11 @@ Examples:
  * Edits the contact at the specified `INDEX`. The index refers to the index number of the contact shown
    in the displayed contact list. The index **must be a positive integer** 1, 2, 3...
 
- * At least one of the contact fields must be provided
-
  * At least one of the optional fields must be provided.
 
  * Existing values will be updated to the input values.
+ 
+ * If the contact has an existing telegram field, you can remove it by typing `te/` without specifying any telegram field after it.
 
  * When editing tags, the existing tags of the contact will be removed i.e adding of tags is not cumulative.
 
@@ -713,6 +713,8 @@ Examples:
     `john` and `john@gmail.com` respectively.
 
   * `editcontact 2 n/Bob Abraham t/` Edits the name of the second contact to be `Bob Abraham` and clears all existing tags of the contact.
+  
+  * `editcontact 1 te/` Deletes the telegram field of the first contact.
 
 
 #### Deleting a contact: `deletecontact`

--- a/src/main/java/seedu/address/logic/commands/contactlistcommands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contactlistcommands/EditContactCommand.java
@@ -105,12 +105,14 @@ public class EditContactCommand extends Command {
         Set<Tag> updatedTags = editContactDescriptor.getTags().orElse(contactToEdit.getTags());
         boolean isImportant = contactToEdit.isImportant();
 
-        if (contactToEdit.getTelegram().isPresent() || editContactDescriptor.getTelegram().isPresent()) {
-            Telegram updatedTelegram = editContactDescriptor.getTelegram()
-                    .orElseGet(() -> contactToEdit.getTelegram().get());
+        if (editContactDescriptor.getTelegram().isPresent()) {
+            Telegram updatedTelegram = editContactDescriptor.getTelegram().get();
             editedContact = new Contact(updatedName, updatedEmail, updatedTelegram, updatedTags, isImportant);
-        } else {
+        } else if (editContactDescriptor.isTelegramDeleted() || !contactToEdit.getTelegram().isPresent()) {
             editedContact = new Contact(updatedName, updatedEmail, updatedTags, isImportant);
+        } else {
+            Telegram updatedTelegram = contactToEdit.getTelegram().get();
+            editedContact = new Contact(updatedName, updatedEmail, updatedTelegram, updatedTags, isImportant);
         }
 
         logger.info("Edited contact created: " + editedContact.toString());

--- a/src/main/java/seedu/address/logic/commands/contactlistcommands/EditContactDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/contactlistcommands/EditContactDescriptor.java
@@ -19,6 +19,7 @@ public class EditContactDescriptor {
     private ContactName name;
     private Email email;
     private Telegram telegram;
+    private boolean isTelegramDeleted = false;
     private Set<Tag> tags;
 
     public EditContactDescriptor() {}
@@ -32,13 +33,14 @@ public class EditContactDescriptor {
         setEmail(toCopy.email);
         setTelegram(toCopy.telegram);
         setTags(toCopy.tags);
+        this.isTelegramDeleted = toCopy.isTelegramDeleted;
     }
 
     /**
      * Returns true if at least one field is edited.
      */
     public boolean isAnyFieldEdited() {
-        return CollectionUtil.isAnyNonNull(name, email, telegram, tags);
+        return CollectionUtil.isAnyNonNull(name, email, telegram, tags) || isTelegramDeleted;
     }
 
     public void setName(ContactName name) {
@@ -63,6 +65,14 @@ public class EditContactDescriptor {
 
     public Optional<Telegram> getTelegram() {
         return Optional.ofNullable(telegram);
+    }
+
+    public void setTelegramDeleted() {
+        this.isTelegramDeleted = true;
+    }
+
+    public boolean isTelegramDeleted() {
+        return this.isTelegramDeleted;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/contactlistparsers/EditContactParser.java
+++ b/src/main/java/seedu/address/logic/parser/contactlistparsers/EditContactParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ZOOM_LINK;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -20,6 +21,7 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.contact.Telegram;
 import seedu.address.model.tag.Tag;
 
 
@@ -47,6 +49,7 @@ public class EditContactParser implements Parser<EditContactCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditContactCommand.MESSAGE_USAGE), pe);
         }
+
         EditContactDescriptor editContactDescriptor = new EditContactDescriptor();
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editContactDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
@@ -57,16 +60,34 @@ public class EditContactParser implements Parser<EditContactCommand> {
         }
 
         if (argMultimap.getValue(PREFIX_TELEGRAM).isPresent()) {
-            editContactDescriptor.setTelegram(ParserUtil.parseTelegram(argMultimap.getValue(PREFIX_TELEGRAM).get()));
+            parseTelegramForEdit(argMultimap.getValue(PREFIX_TELEGRAM).get())
+                    .ifPresentOrElse(telegram -> editContactDescriptor.setTelegram(telegram),
+                            () -> editContactDescriptor.setTelegramDeleted());
         }
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editContactDescriptor::setTags);
-
         if (!editContactDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditContactCommand.MESSAGE_NOT_EDITED);
         }
 
         return new EditContactCommand(index, editContactDescriptor);
+    }
+
+    /**
+     * Parses the String containing the edited telegram into a {@code Telegram} if the String is non-empty.
+     *
+     * @param telegram String containing the telegram argument.
+     * @return Optional describing a Telegram object.
+     * @throws ParseException If the telegram argument does not conform the expected format.
+     */
+    private Optional<Telegram> parseTelegramForEdit(String telegram) throws ParseException {
+        requireNonNull(telegram);
+
+        if (telegram.isBlank()) {
+            return Optional.empty();
+        }
+        Telegram editedTelegram =  ParserUtil.parseTelegram(telegram);
+        return Optional.of(editedTelegram);
     }
 
     /**


### PR DESCRIPTION
This PR fixes #591 

This PR address the issue of users being unable to delete a telegram field of a contact despite it being an optional field.

The following classes have been modified:
1. `EditContactDescriptor`: Store an additional boolean field to indicate if users wish to delete the telegram field of a contact
2. `EditContactParser`: handle the case when no argument for the `te/` prefix was provided
3. `EditContactCommand`: handle the execution of the correct command

Additionally, the user guide was updated to inform users of this feature.