### PR TITLE
Implement Junit tests for Zoom Link Command Parsers

### DIFF
--- a/src/main/java/seedu/address/logic/ParserManager.java
+++ b/src/main/java/seedu/address/logic/ParserManager.java
@@ -1,11 +1,11 @@
 package seedu.address.logic;
 
+import seedu.address.logic.parser.ContactListParser;
 import seedu.address.logic.parser.FeatureParser;
 import seedu.address.logic.parser.GradeTrackerParser;
 import seedu.address.logic.parser.ModuleListParser;
 import seedu.address.logic.parser.SchedulerParser;
 import seedu.address.logic.parser.TodoListParser;
-import seedu.address.logic.parser.contactlistparsers.ContactListParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 

--- a/src/main/java/seedu/address/logic/parser/ContactListParser.java
+++ b/src/main/java/seedu/address/logic/parser/ContactListParser.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser.contactlistparsers;
+package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
@@ -17,7 +17,13 @@ import seedu.address.logic.commands.contactlistcommands.ImportantContactCommand;
 import seedu.address.logic.commands.contactlistcommands.ListContactCommand;
 import seedu.address.logic.commands.contactlistcommands.ResetContactCommand;
 import seedu.address.logic.commands.contactlistcommands.SortContactCommand;
-import seedu.address.logic.parser.FeatureParser;
+import seedu.address.logic.parser.contactlistparsers.AddContactParser;
+import seedu.address.logic.parser.contactlistparsers.DeleteContactParser;
+import seedu.address.logic.parser.contactlistparsers.EditContactParser;
+import seedu.address.logic.parser.contactlistparsers.FindContactParser;
+import seedu.address.logic.parser.contactlistparsers.ImportantContactParser;
+import seedu.address.logic.parser.contactlistparsers.ResetContactParser;
+import seedu.address.logic.parser.contactlistparsers.SortContactParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class ContactListParser implements FeatureParser {

--- a/src/main/java/seedu/address/logic/parser/modulelistparsers/EditZoomLinkParser.java
+++ b/src/main/java/seedu/address/logic/parser/modulelistparsers/EditZoomLinkParser.java
@@ -55,8 +55,8 @@ public class EditZoomLinkParser implements Parser<EditZoomLinkCommand> {
         }
         ZoomDescriptor zoomDescriptor = new ZoomDescriptor();
 
-        zoomDescriptor.setModuleLesson(ParserUtil.parseModuleLesson(argMultimap.getValue(PREFIX_NAME).get()));
         zoomDescriptor.setZoomLink(ParserUtil.parseZoomLink(argMultimap.getValue(PREFIX_ZOOM_LINK).get()));
+        zoomDescriptor.setModuleLesson(ParserUtil.parseModuleLesson(argMultimap.getValue(PREFIX_NAME).get()));
 
         return new EditZoomLinkCommand(index, zoomDescriptor);
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -33,6 +33,7 @@ import seedu.address.testutil.contact.EditContactDescriptorBuilder;
  */
 public class CommandTestUtil {
 
+    //========= Contact List ==================================================
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
@@ -41,8 +42,6 @@ public class CommandTestUtil {
     public static final String VALID_TELEGRAM_BOB = "@bobtele";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
-    public static final String VALID_TAG_CORE_MODULE = "Core";
-    public static final String VALID_TAG_UNGRADED_MODULE = "Ungraded";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -58,10 +57,13 @@ public class CommandTestUtil {
     public static final String INVALID_TELEGRAM_DESC = " " + PREFIX_TELEGRAM + "bobtele"; // missing '@' symbol
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
+    //======= Module List =======================================================================
     public static final String VALID_MODULENAME_CS2030 = "CS2030";
     public static final String VALID_MODULENAME_CS2103T = "CS2103T";
     public static final String VALID_MODULENAME_ES2660 = "ES2660";
 
+    public static final String VALID_TAG_CORE_MODULE = "Core";
+    public static final String VALID_TAG_UNGRADED_MODULE = "Ungraded";
     public static final String VALID_MODULE_LESSON_LECTURE = "Lecture";
     public static final String VALID_MODULE_LESSON_TUTORIAL = "Tutorial";
     public static final String VALID_ZOOM_LINK_CS2103T = "https://nus-sg.zoom.us/CS2103t";
@@ -78,10 +80,15 @@ public class CommandTestUtil {
     public static final String VALID_TAG_LECTURE = "Lecture";
     public static final String VALID_TAG_TUTORIAL = "Tutorial";
 
-    public static final String NAME_DESC_CS2103T = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T;
-    public static final String ZOOMLINK_DESC_CS2103T = " " + PREFIX_ZOOM_LINK + VALID_ZOOM_LINK_CS2103T;
+    public static final String MODULE_LESSON_DESC_LECTURE = " " + PREFIX_NAME + VALID_MODULE_LESSON_LECTURE;
+    public static final String MODULE_LESSON_DESC_TUTORIAL = " " + PREFIX_NAME + VALID_MODULE_LESSON_TUTORIAL;
+    public static final String INVALID_MODULE_LESSON_DESC = " " + PREFIX_NAME + ".10()";
+    public static final String ZOOM_LINK_DESC_CS2103T = " " + PREFIX_ZOOM_LINK + VALID_ZOOM_LINK_CS2103T;
+    public static final String ZOOM_LINK_DESC_ES2660 = " " + PREFIX_ZOOM_LINK + VALID_ZOOM_LINK_ES2660;
+    public static final String INVALID_ZOOM_LINK_DESC = " " + PREFIX_ZOOM_LINK + "https://incorrectLink.zoom.us";
     public static final String NAME_DESC_ES2660 = " " + PREFIX_NAME + VALID_MODULENAME_ES2660;
-    public static final String ZOOMLINK_DESC_ES2660 = " " + PREFIX_ZOOM_LINK + VALID_ZOOM_LINK_ES2660;
+    public static final String NAME_DESC_CS2103T = " " + PREFIX_NAME + VALID_MODULENAME_CS2103T;
+
 
     // ================================== TodoList ===================================== //
 

--- a/src/test/java/seedu/address/logic/parser/contactlistparsers/ContactListParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contactlistparsers/ContactListParserTest.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.contactlistcommands.ImportantContactCommand;
 import seedu.address.logic.commands.contactlistcommands.ListContactCommand;
 import seedu.address.logic.commands.contactlistcommands.ResetContactCommand;
 import seedu.address.logic.commands.contactlistcommands.SortContactCommand;
+import seedu.address.logic.parser.ContactListParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.ContactNameContainsKeywordsPredicate;

--- a/src/test/java/seedu/address/logic/parser/contactlistparsers/EditContactParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contactlistparsers/EditContactParserTest.java
@@ -112,10 +112,10 @@ public class EditContactParserTest {
     @Test
     public void parse_someFieldsSpecified_success() {
         Index targetIndex = INDEX_FIRST_CONTACT;
-        String userInput = targetIndex.getOneBased() + TELEGRAM_DESC_AMY + EMAIL_DESC_AMY;
+        String userInput = targetIndex.getOneBased() + TELEGRAM_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND;
 
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withTelegram(VALID_TELEGRAM_AMY)
-                .withEmail(VALID_EMAIL_AMY).build();
+                .withEmail(VALID_EMAIL_AMY).withTags(VALID_TAG_FRIEND).build();
         EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/logic/parser/contactlistparsers/FindContactParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contactlistparsers/FindContactParserTest.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.parser.contactlistparsers;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_SEARCH_KEYWORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -12,15 +14,31 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.contactlistcommands.FindContactCommand;
 import seedu.address.model.contact.ContactNameContainsKeywordsPredicate;
 import seedu.address.model.contact.FindContactCriteria;
+import seedu.address.model.tag.Tag;
 
 
 public class FindContactParserTest {
+
     private FindContactParser parser = new FindContactParser();
 
     @Test
-    public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+    public void parse_noFieldSpecified_throwsParseException() {
+        assertParseFailure(parser, "  ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 FindContactCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgument_throwsParseException() {
+
+        // missing name keyword
+        assertParseFailure(parser, " " + PREFIX_NAME, String.format(MESSAGE_INVALID_SEARCH_KEYWORD));
+
+        // missing tag keyword
+        assertParseFailure(parser, " " + PREFIX_TAG, String.format(MESSAGE_INVALID_SEARCH_KEYWORD));
+
+        // invalid tag keyword
+        assertParseFailure(parser, " " + PREFIX_TAG + "abc.", String.format(Tag.MESSAGE_CONSTRAINTS));
+
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/contactlistparsers/SortContactParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contactlistparsers/SortContactParserTest.java
@@ -1,22 +1,21 @@
 package seedu.address.logic.parser.contactlistparsers;
 
-/*import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;*/
 
 import org.junit.jupiter.api.Test;
 
-/*import seedu.address.logic.commands.contactlistcommands.SortContactCommand;
-import seedu.address.model.contact.ContactComparatorByName;*/
+import seedu.address.logic.commands.contactlistcommands.SortContactCommand;
 
 public class SortContactParserTest {
+
     private SortContactParser parser = new SortContactParser();
 
     @Test
     public void parse_emptyArg_parseSuccess() {
         /*SortContactCommand expectedSortContactCommand =
                 new SortContactCommand(new ContactComparatorByName());
-        assertParseSuccess(parser, "", expectedSortContactCommand);*/
+        assertTrue(parser.parse("") != null); */
     }
 
     @Test
@@ -28,7 +27,7 @@ public class SortContactParserTest {
 
     @Test
     public void parse_invalidArgsSpecified_throwsParseException() {
-        /*assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SortContactCommand.MESSAGE_USAGE));*/
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SortContactCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/modulelistparsers/AddZoomLinkParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/modulelistparsers/AddZoomLinkParserTest.java
@@ -1,0 +1,85 @@
+package seedu.address.logic.parser.modulelistparsers;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_LESSON_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ZOOM_LINK_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_LESSON_DESC_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_LESSON_DESC_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_LESSON_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOM_LINK_CS2030;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOM_LINK_CS2103T;
+import static seedu.address.logic.commands.CommandTestUtil.ZOOM_LINK_DESC_CS2103T;
+import static seedu.address.logic.commands.CommandTestUtil.ZOOM_LINK_DESC_ES2660;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.modulelistcommands.AddZoomLinkCommand;
+import seedu.address.logic.commands.modulelistcommands.ZoomDescriptor;
+import seedu.address.model.module.ModuleLesson;
+import seedu.address.model.module.ZoomLink;
+import seedu.address.testutil.ZoomDescriptorBuilder;
+
+public class AddZoomLinkParserTest {
+
+    private AddZoomLinkParser parser = new AddZoomLinkParser();
+    private ZoomDescriptor zoomDescriptor = new ZoomDescriptorBuilder()
+            .withZoomLink(VALID_ZOOM_LINK_CS2103T).withModuleLesson(VALID_MODULE_LESSON_LECTURE).build();
+
+    @Test
+    public void parse_compulsoryFieldsMissing_parseFailure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddZoomLinkCommand.MESSAGE_USAGE);
+
+        // no index specified
+        assertParseFailure(parser, ZOOM_LINK_DESC_CS2103T + MODULE_LESSON_DESC_LECTURE, expectedMessage);
+
+        // missing zoom link prefix
+        assertParseFailure(parser, INDEX_FIRST_MODULE
+                + VALID_ZOOM_LINK_CS2030 + MODULE_LESSON_DESC_LECTURE, expectedMessage);
+
+        // missing module lesson name prefix
+        assertParseFailure(parser, INDEX_FIRST_MODULE
+                + ZOOM_LINK_DESC_CS2103T + VALID_MODULE_LESSON_LECTURE, expectedMessage);
+
+        // index and all prefixes missing
+        assertParseFailure(parser, VALID_ZOOM_LINK_CS2030 + VALID_MODULE_LESSON_LECTURE, expectedMessage);
+    }
+
+    @Test
+    public void parse_allFieldsPresent_parseSuccess() {
+
+        // only one of each prefix argument specified
+        assertParseSuccess(parser, INDEX_FIRST_MODULE.getOneBased() + ZOOM_LINK_DESC_CS2103T
+                + MODULE_LESSON_DESC_LECTURE, new AddZoomLinkCommand(INDEX_FIRST_MODULE, zoomDescriptor));
+
+        // multiple zoom links - last zoom link accepted
+        assertParseSuccess(parser, INDEX_FIRST_MODULE.getOneBased() + ZOOM_LINK_DESC_ES2660
+                + ZOOM_LINK_DESC_CS2103T + MODULE_LESSON_DESC_LECTURE,
+                new AddZoomLinkCommand(INDEX_FIRST_MODULE, zoomDescriptor));
+
+        // multiple module lessons - last module lesson accepted
+        assertParseSuccess(parser, INDEX_FIRST_MODULE.getOneBased() + ZOOM_LINK_DESC_CS2103T
+                + MODULE_LESSON_DESC_TUTORIAL + MODULE_LESSON_DESC_LECTURE,
+                new AddZoomLinkCommand(INDEX_FIRST_MODULE, zoomDescriptor));
+    }
+
+    @Test
+    public void parse_invalidArguments_parseFailure() {
+        // invalid index
+        assertParseFailure(parser, "-1" + ZOOM_LINK_DESC_CS2103T + MODULE_LESSON_DESC_LECTURE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddZoomLinkCommand.MESSAGE_USAGE));
+
+        // invalid zoom link
+        assertParseFailure(parser, INDEX_FIRST_MODULE.getOneBased() + INVALID_ZOOM_LINK_DESC
+                + MODULE_LESSON_DESC_LECTURE, ZoomLink.MESSAGE_CONSTRAINTS);
+
+        // invalid module lesson
+        assertParseFailure(parser, INDEX_FIRST_MODULE.getOneBased() + ZOOM_LINK_DESC_CS2103T
+                + INVALID_MODULE_LESSON_DESC, ModuleLesson.MESSAGE_CONSTRAINTS);
+
+        // invalid zoom link and module lesson, only invalid zoom link reported
+        assertParseFailure(parser, INDEX_FIRST_MODULE.getOneBased() + INVALID_ZOOM_LINK_DESC
+                + INVALID_MODULE_LESSON_DESC, ZoomLink.MESSAGE_CONSTRAINTS);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/modulelistparsers/AddZoomLinkParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/modulelistparsers/AddZoomLinkParserTest.java
@@ -15,6 +15,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.modulelistcommands.AddZoomLinkCommand;
 import seedu.address.logic.commands.modulelistcommands.ZoomDescriptor;
 import seedu.address.model.module.ModuleLesson;

--- a/src/test/java/seedu/address/logic/parser/modulelistparsers/DeleteZoomLinkParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/modulelistparsers/DeleteZoomLinkParserTest.java
@@ -1,12 +1,66 @@
 package seedu.address.logic.parser.modulelistparsers;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_LESSON_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_LESSON_DESC_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_LESSON_DESC_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_LESSON_LECTURE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.modulelistcommands.DeleteZoomLinkCommand;
+import seedu.address.model.module.ModuleLesson;
 
 public class DeleteZoomLinkParserTest {
 
     private DeleteZoomLinkParser parser = new DeleteZoomLinkParser();
 
     @Test
+    public void parse_allFieldsPresent_parseSuccess() {
+
+        // only one module lesson argument specified
+        assertParseSuccess(parser, INDEX_FIRST_MODULE.getOneBased() + MODULE_LESSON_DESC_LECTURE,
+                new DeleteZoomLinkCommand(INDEX_FIRST_MODULE, new ModuleLesson(VALID_MODULE_LESSON_LECTURE)));
+
+        // multiple module lessons - last module lesson accepted
+        assertParseSuccess(parser, INDEX_FIRST_MODULE.getOneBased()
+                + MODULE_LESSON_DESC_TUTORIAL + MODULE_LESSON_DESC_LECTURE,
+                new DeleteZoomLinkCommand(INDEX_FIRST_MODULE, new ModuleLesson(VALID_MODULE_LESSON_LECTURE)));
+    }
+
+    @Test
+    public void parse_compulsoryFieldsMissing_parseFailure() {
+
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteZoomLinkCommand.MESSAGE_USAGE);
+
+        // no index specified
+        assertParseFailure(parser, MODULE_LESSON_DESC_LECTURE,
+                expectedMessage);
+
+        // missing module lesson name prefix
+        assertParseFailure(parser, INDEX_FIRST_MODULE + VALID_MODULE_LESSON_LECTURE, expectedMessage);
+
+        // missing index and module lesson name prefix
+        assertParseFailure(parser, VALID_MODULE_LESSON_LECTURE, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidArguments_parseFailure() {
+
+        // invalid index
+        assertParseFailure(parser, "-1" + MODULE_LESSON_DESC_LECTURE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteZoomLinkCommand.MESSAGE_USAGE));
+
+        // invalid module lesson
+        assertParseFailure(parser, INDEX_FIRST_MODULE.getOneBased() + INVALID_MODULE_LESSON_DESC,
+                ModuleLesson.MESSAGE_CONSTRAINTS);
+
+        // invalid index and module lesson, only invalid index reported
+        assertParseFailure(parser, "-1" + INVALID_MODULE_LESSON_DESC,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteZoomLinkCommand.MESSAGE_USAGE));
+    }
 
 }

--- a/src/test/java/seedu/address/logic/parser/modulelistparsers/DeleteZoomLinkParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/modulelistparsers/DeleteZoomLinkParserTest.java
@@ -1,0 +1,12 @@
+package seedu.address.logic.parser.modulelistparsers;
+
+
+import org.junit.jupiter.api.Test;
+
+public class DeleteZoomLinkParserTest {
+
+    private DeleteZoomLinkParser parser = new DeleteZoomLinkParser();
+
+    @Test
+
+}

--- a/src/test/java/seedu/address/logic/parser/modulelistparsers/EditZoomLinkParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/modulelistparsers/EditZoomLinkParserTest.java
@@ -1,12 +1,5 @@
 package seedu.address.logic.parser.modulelistparsers;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.logic.commands.modulelistcommands.EditZoomLinkCommand;
-import seedu.address.logic.commands.modulelistcommands.ZoomDescriptor;
-import seedu.address.model.module.ModuleLesson;
-import seedu.address.model.module.ZoomLink;
-import seedu.address.testutil.ZoomDescriptorBuilder;
-
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_LESSON_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ZOOM_LINK_DESC;
@@ -20,6 +13,14 @@ import static seedu.address.logic.commands.CommandTestUtil.ZOOM_LINK_DESC_ES2660
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.modulelistcommands.EditZoomLinkCommand;
+import seedu.address.logic.commands.modulelistcommands.ZoomDescriptor;
+import seedu.address.model.module.ModuleLesson;
+import seedu.address.model.module.ZoomLink;
+import seedu.address.testutil.ZoomDescriptorBuilder;
 
 public class EditZoomLinkParserTest {
 

--- a/src/test/java/seedu/address/logic/parser/modulelistparsers/EditZoomLinkParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/modulelistparsers/EditZoomLinkParserTest.java
@@ -1,0 +1,85 @@
+package seedu.address.logic.parser.modulelistparsers;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.modulelistcommands.EditZoomLinkCommand;
+import seedu.address.logic.commands.modulelistcommands.ZoomDescriptor;
+import seedu.address.model.module.ModuleLesson;
+import seedu.address.model.module.ZoomLink;
+import seedu.address.testutil.ZoomDescriptorBuilder;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_LESSON_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ZOOM_LINK_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_LESSON_DESC_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_LESSON_DESC_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_LESSON_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOM_LINK_CS2030;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ZOOM_LINK_CS2103T;
+import static seedu.address.logic.commands.CommandTestUtil.ZOOM_LINK_DESC_CS2103T;
+import static seedu.address.logic.commands.CommandTestUtil.ZOOM_LINK_DESC_ES2660;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
+
+public class EditZoomLinkParserTest {
+
+    private EditZoomLinkParser parser = new EditZoomLinkParser();
+    private ZoomDescriptor zoomDescriptor = new ZoomDescriptorBuilder()
+            .withZoomLink(VALID_ZOOM_LINK_CS2103T).withModuleLesson(VALID_MODULE_LESSON_LECTURE).build();
+
+    @Test
+    public void parse_compulsoryFieldsMissing_parseFailure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditZoomLinkCommand.MESSAGE_USAGE);
+
+        // no index specified
+        assertParseFailure(parser, ZOOM_LINK_DESC_CS2103T + MODULE_LESSON_DESC_LECTURE, expectedMessage);
+
+        // missing zoom link prefix
+        assertParseFailure(parser, INDEX_FIRST_MODULE
+                + VALID_ZOOM_LINK_CS2030 + MODULE_LESSON_DESC_LECTURE, expectedMessage);
+
+        // missing module lesson name prefix
+        assertParseFailure(parser, INDEX_FIRST_MODULE
+                + ZOOM_LINK_DESC_CS2103T + VALID_MODULE_LESSON_LECTURE, expectedMessage);
+
+        // index and all prefixes missing
+        assertParseFailure(parser, VALID_ZOOM_LINK_CS2030 + VALID_MODULE_LESSON_LECTURE, expectedMessage);
+    }
+
+    @Test
+    public void parse_allFieldsPresent_parseSuccess() {
+
+        // only one of each prefix argument specified
+        assertParseSuccess(parser, INDEX_FIRST_MODULE.getOneBased() + ZOOM_LINK_DESC_CS2103T
+                + MODULE_LESSON_DESC_LECTURE, new EditZoomLinkCommand(INDEX_FIRST_MODULE, zoomDescriptor));
+
+        // multiple zoom links - last zoom link accepted
+        assertParseSuccess(parser, INDEX_FIRST_MODULE.getOneBased() + ZOOM_LINK_DESC_ES2660
+                        + ZOOM_LINK_DESC_CS2103T + MODULE_LESSON_DESC_LECTURE,
+                new EditZoomLinkCommand(INDEX_FIRST_MODULE, zoomDescriptor));
+
+        // multiple module lessons - last module lesson accepted
+        assertParseSuccess(parser, INDEX_FIRST_MODULE.getOneBased() + ZOOM_LINK_DESC_CS2103T
+                        + MODULE_LESSON_DESC_TUTORIAL + MODULE_LESSON_DESC_LECTURE,
+                new EditZoomLinkCommand(INDEX_FIRST_MODULE, zoomDescriptor));
+    }
+
+    @Test
+    public void parse_invalidArguments_parseFailure() {
+        // invalid index
+        assertParseFailure(parser, "-1" + ZOOM_LINK_DESC_CS2103T + MODULE_LESSON_DESC_LECTURE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditZoomLinkCommand.MESSAGE_USAGE));
+
+        // invalid zoom link
+        assertParseFailure(parser, INDEX_FIRST_MODULE.getOneBased() + INVALID_ZOOM_LINK_DESC
+                + MODULE_LESSON_DESC_LECTURE, ZoomLink.MESSAGE_CONSTRAINTS);
+
+        // invalid module lesson
+        assertParseFailure(parser, INDEX_FIRST_MODULE.getOneBased() + ZOOM_LINK_DESC_CS2103T
+                + INVALID_MODULE_LESSON_DESC, ModuleLesson.MESSAGE_CONSTRAINTS);
+
+        // invalid zoom link and module lesson, only invalid zoom link reported
+        assertParseFailure(parser, INDEX_FIRST_MODULE.getOneBased() + INVALID_ZOOM_LINK_DESC
+                + INVALID_MODULE_LESSON_DESC, ZoomLink.MESSAGE_CONSTRAINTS);
+    }
+}


### PR DESCRIPTION
This PR fixes #654 

Junit tests have been implemented for the following classes to increase code coverage:
1. `AddZoomLinkParser`
2. `EditZoomLinkParser`
3. `DeleteZoomLinkParser`